### PR TITLE
Covid19 test provider list results adjustments

### DIFF
--- a/src/server/views/lists/partials/covid-test-providers/macros.njk
+++ b/src/server/views/lists/partials/covid-test-providers/macros.njk
@@ -14,23 +14,18 @@
       {{ "-" if item.address.postCode }} {{ item.address.postCode }} 
       {{ "-" if item.address.city }} {{ item.address.city }}
   </p>
-  {% if item.jsonData.email %}
-    <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-      <strong>Email</strong>: <a class="govuk-link" href="mailto:{{ item.jsonData.email }}">{{ item.jsonData.email }}</a>
-    </p>
-  {% endif %}
+  <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
+        <strong>Available tests</strong>:
+        {% for item in _.orderBy(item.jsonData.providedTests, ["turnaroundTime"]) %}
+          {{ item.type }} (results in {{item.turnaroundTime}} hour{{ "s" if item.turnaroundTime > 1}}){{", " if not loop.last}}
+        {% endfor %}
+      </p>
   {% if item.jsonData.website %}
     <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
       <strong>Website</strong>: <a class="govuk-link" href="{{ enforceHttps(item.jsonData.website) }}" rel="noopener noreferrer" target="_blank">{{ item.jsonData.website }}</a>
     </p>
   {% endif %}
-
-  {% if (not item.jsonData.email) or (not item.jsonData.website) %}
-    <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-      <strong>Telephone</strong>: {{ item.jsonData.telephone }}
-    </p>
-  {% endif %}
-
+  
   <details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
@@ -43,12 +38,11 @@
           <strong>Telephone</strong>: {{ item.jsonData.telephone }}
         </p>  
       {% endif %}
-      <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-        <strong>Available tests</strong>:
-        {% for item in _.orderBy(item.jsonData.providedTests, ["turnaroundTime"]) %}
-          {{ item.type }} (results in {{item.turnaroundTime}} hour{{ "s" if item.turnaroundTime > 1}}){{", " if not loop.last}}
-        {% endfor %}
-      </p>
+      {% if item.jsonData.email %}
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
+          <strong>Email</strong>: <a class="govuk-link" href="mailto:{{ item.jsonData.email }}">{{ item.jsonData.email }}</a>
+        </p>
+      {% endif %}
       <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
         <strong>Results formats</strong>: {{ item.jsonData.resultsFormat.map(_.startCase).join(", ") }}
       </p>

--- a/src/server/views/lists/partials/covid-test-providers/macros.njk
+++ b/src/server/views/lists/partials/covid-test-providers/macros.njk
@@ -8,9 +8,6 @@
     </p>
   {% endif %}
   <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-    <strong>Opening times</strong>: {{ item.jsonData.openingTimes }}
-  </p>
-  <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
     <strong>Address</strong>: 
       {{ item.address.firstLine }} 
       {{ "-" if item.address.secondLine }} {{ item.address.secondLine }}
@@ -47,16 +44,16 @@
         </p>  
       {% endif %}
       <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-        <strong>Turnaround time</strong>: {{ item.jsonData.turnaroundTime }} hour{{ "s" if item.jsonData.turnaroundTime > 1}} 
+        <strong>Available tests</strong>:
+        {% for item in _.orderBy(item.jsonData.providedTests, ["turnaroundTime"]) %}
+          {{ item.type }} (results in {{item.turnaroundTime}} hour{{ "s" if item.turnaroundTime > 1}}){{", " if not loop.last}}
+        {% endfor %}
       </p>
       <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
         <strong>Results formats</strong>: {{ item.jsonData.resultsFormat.map(_.startCase).join(", ") }}
       </p>
       <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
         <strong>Provide results when closed</strong>: {{ "Yes" if item.jsonData.provideResultsWhenClosed else "No" }}
-      </p>
-      <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-        <strong>Provides certificate translation</strong>: {{ "Yes" if item.jsonData.provideResultsInEnglishFrenchSpanish else "No" }}
       </p>
       <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
         <strong>Booking options</strong>: {{ item.jsonData.bookingOptions.map(_.startCase).join(", ") }}


### PR DESCRIPTION
Display available tests information outside details section.
Move email information inside details section.
Deprecate opening times information. 