### PR TITLE
Covid19 test providers `Additional email address` and `Additional phone number` fields

### DIFF
--- a/src/form-runner/forms-json/covid-test-providers.json
+++ b/src/form-runner/forms-json/covid-test-providers.json
@@ -186,6 +186,15 @@
           "nameHasError": false,
           "schema": {},
           "hint": "This is the email address your organisation wishes to be contacted on by British nationals. This will be published on GOV.UK."
+        },
+        {
+          "name": "additionalEmailAddress",
+          "options": {
+            "required": false
+          },
+          "type": "EmailAddressField",
+          "title": "Additional email address",
+          "nameHasError": false
         }
       ],
       "next": [
@@ -275,6 +284,15 @@
           "type": "TextField",
           "title": "Phone number",
           "hint": "This is the phone number your company or facility wishes to be contacted on by British nationals. This will be published on GOV.UK.",
+          "nameHasError": false
+        },
+        {
+          "name": "additionalPhoneNumber",
+          "options": {
+            "required": false
+          },
+          "type": "TextField",
+          "title": "Additional phone number",
           "nameHasError": false
         }
       ],

--- a/src/form-runner/install-form-runner.sh
+++ b/src/form-runner/install-form-runner.sh
@@ -13,7 +13,7 @@ then
   echo "Form Runner Already Installed"
 else
   echo "Installing Form Runner"
-  git clone --depth 1 --branch 3.1.0-rc.9042 https://github.com/XGovFormBuilder/digital-form-builder.git $form_runner_folder
+  git clone --depth 1 --branch 3.9.6-rc.780 https://github.com/XGovFormBuilder/digital-form-builder.git $form_runner_folder
   cd $form_runner_folder
   yarn install
   yarn run build:dependencies

--- a/src/server/models/listItem.ts
+++ b/src/server/models/listItem.ts
@@ -647,7 +647,9 @@ async function createCovidTestSupplierListItemObject(
           .toLocaleLowerCase()
           .trim(),
         telephone: formData.organisationDetails.phoneNumber,
+        additionalTelephone: formData.organisationDetails.additionalPhoneNumber,
         email: formData.organisationDetails.emailAddress.toLowerCase().trim(),
+        additionalEmail: formData.organisationDetails.additionalEmailAddress,
         website: formData.organisationDetails.websiteAddress
           .toLowerCase()
           .trim(),

--- a/src/server/models/types.ts
+++ b/src/server/models/types.ts
@@ -101,7 +101,9 @@ export interface CovidTestSupplierListItemJsonData extends JsonObject {
   contactPhoneNumber: string;
   contactEmailAddress: string;
   telephone: string;
+  additionalTelephone?: string;
   email: string;
+  additionalEmail?: string;
   website: string;
   regulatoryAuthority: string;
   resultsReadyFormat: string[];

--- a/src/server/services/form-runner/types.ts
+++ b/src/server/services/form-runner/types.ts
@@ -65,7 +65,9 @@ export interface CovidTestSupplierFormWebhookData {
     contactPhoneNumber: string;
     websiteAddress: string;
     emailAddress: string;
+    additionalEmailAddress?: string;
     phoneNumber: string;
+    additionalPhoneNumber?: string;
     addressLine1: string;
     addressLine2: string | undefined;
     city: string;

--- a/src/server/views/lists/partials/covid-test-providers/macros.njk
+++ b/src/server/views/lists/partials/covid-test-providers/macros.njk
@@ -35,12 +35,20 @@
     <div class="govuk-details__text">
       {% if (item.jsonData.email) and (item.jsonData.website) %}
         <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-          <strong>Telephone</strong>: <a class="telephone" href="tel:{{ item.jsonData.telephone }}">{{ item.jsonData.telephone }}</a>
+          <strong>Telephone</strong>: 
+          <a class="govuk-link telephone" href="tel:{{ item.jsonData.telephone }}">{{ item.jsonData.telephone }}</a>{{", " if item.jsonData.additionalTelephone}}
+          {% if item.jsonData.additionalTelephone %}
+            <a class="govuk-link telephone" href="tel:{{ item.jsonData.additionalTelephone }}">{{ item.jsonData.additionalTelephone }}</a>
+          {% endif %}
         </p>  
       {% endif %}
       {% if item.jsonData.email %}
         <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-          <strong>Email</strong>: <a class="govuk-link email" href="mailto:{{ item.jsonData.email }}">{{ item.jsonData.email }}</a>
+          <strong>Email</strong>: 
+            <a class="govuk-link email" href="mailto:{{ item.jsonData.email }}">{{ item.jsonData.email }}</a>{{", " if item.jsonData.additionalEmail}}
+            {% if item.jsonData.additionalEmail %}
+            <a class="govuk-link email" href="tel:{{ item.jsonData.additionalEmail }}">{{ item.jsonData.additionalEmail }}</a>
+          {% endif %}
         </p>
       {% endif %}
       <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">


### PR DESCRIPTION
Add `Additional email address` and `Additional phone number` fields for form journey.
Refactor ingestion code to include two new fields.
Extend covid test providers list item with addtional email and telephone.
Upgrade form runner dependency.