### PR TITLE
Adjust cookies policy bug with form-runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "engines": {
     "node": ">=14"
   },

--- a/src/form-runner/install-form-runner.sh
+++ b/src/form-runner/install-form-runner.sh
@@ -13,7 +13,7 @@ then
   echo "Form Runner Already Installed"
 else
   echo "Installing Form Runner"
-  git clone --depth 1 --branch 3.9.6-rc.780 https://github.com/XGovFormBuilder/digital-form-builder.git $form_runner_folder
+  git clone --depth 1 --branch 3.9.7-rc.781 https://github.com/XGovFormBuilder/digital-form-builder.git $form_runner_folder
   cd $form_runner_folder
   yarn install
   yarn run build:dependencies

--- a/src/server/__tests__/cookies.test.ts
+++ b/src/server/__tests__/cookies.test.ts
@@ -81,7 +81,7 @@ describe("Cookies", () => {
     });
 
     test("accept analytics works correctly", async () => {
-      const { text, headers } = await request(server)
+      const { text } = await request(server)
         .post(pageLink)
         .type("form")
         .send({ analytics: "on" });

--- a/src/server/__tests__/cookies.test.ts
+++ b/src/server/__tests__/cookies.test.ts
@@ -90,17 +90,7 @@ describe("Cookies", () => {
       const radios = $html(":radio");
       const successBanner = $html(".govuk-notification-banner");
 
-      const cookiesPolicy = headers["set-cookie"]
-        .find((elm: string) => elm?.includes("cookies_policy"))
-        .split("=")[1]
-        .split(";")[0]
-        .trim();
-
       expect(successBanner.length).toBe(1);
-      expect(cookiesPolicy).toEqual(
-        encodeURIComponent(JSON.stringify({ isSet: true, essential: true, analytics: "on", usage: true }))
-      );
-
       expect(radios.eq(0).attr("name")).toBe("analytics");
       expect(radios.eq(0).attr("checked")).toBe("checked");
       expect(radios.eq(0).attr("value")).toBe("on");
@@ -128,7 +118,7 @@ describe("Cookies", () => {
 
       expect(successBanner.length).toBe(1);
       expect(cookiesPolicy).toEqual(
-        encodeURIComponent(JSON.stringify({ isSet: true, essential: true, analytics: "off", usage: false }))
+        Buffer.from(JSON.stringify({ isSet: true, essential: true, analytics: "off", usage: false })).toString("base64")
       );
 
       expect(radios.eq(0).attr("name")).toBe("analytics");

--- a/src/server/controllers/cookies/index.ts
+++ b/src/server/controllers/cookies/index.ts
@@ -1,2 +1,2 @@
 export { cookiesPageRoute } from "./constants";
-export { cookiesPageGETController, cookiesPagePOSTController } from "./cookies";
+export { cookiesGETController, cookiesPOSTController } from "./cookies";

--- a/src/server/middlewares/views.ts
+++ b/src/server/middlewares/views.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { Buffer } from 'buffer';
 import _, { get } from "lodash";
 import nunjucks from "nunjucks";
 import { Express } from "express";
@@ -37,7 +38,7 @@ export const configureViews = (server: Express): void => {
 
     try {
       cookiesPolicy = JSON.parse(
-        get(req, "cookies.cookies_policy", "{}")
+        Buffer.from(get(req, "cookies.cookies_policy", "{}"), 'base64').toString('ascii')
       );
     } catch (error) {
       // cleanup legacy json cookie

--- a/src/server/middlewares/views.ts
+++ b/src/server/middlewares/views.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { Buffer } from 'buffer';
+import { Buffer } from "buffer";
 import _, { get } from "lodash";
 import nunjucks from "nunjucks";
 import { Express } from "express";
@@ -15,6 +15,8 @@ const VIEWS_PATHS = [
   path.join(ROOT, "/node_modules/govuk-frontend/govuk/"),
   path.join(ROOT, "/node_modules/govuk-frontend/govuk/components"),
 ];
+
+const EMPTY_BASE64_COOKIE = Buffer.from(JSON.stringify({})).toString("base64");
 
 export const configureViews = (server: Express): void => {
   server.engine("html", nunjucks.render);
@@ -38,7 +40,10 @@ export const configureViews = (server: Express): void => {
 
     try {
       cookiesPolicy = JSON.parse(
-        Buffer.from(get(req, "cookies.cookies_policy", "{}"), 'base64').toString('ascii')
+        Buffer.from(
+          get(req, "cookies.cookies_policy", EMPTY_BASE64_COOKIE),
+          "base64"
+        ).toString("ascii")
       );
     } catch (error) {
       // cleanup legacy json cookie

--- a/src/server/routes/cookies.ts
+++ b/src/server/routes/cookies.ts
@@ -1,13 +1,13 @@
 import express from "express";
 import {
   cookiesPageRoute,
-  cookiesPageGETController,
-  cookiesPagePOSTController,
+  cookiesGETController,
+  cookiesPOSTController,
 } from "server/controllers/cookies";
 
 const router = express.Router();
 
-router.get(cookiesPageRoute, cookiesPageGETController);
-router.post(cookiesPageRoute, cookiesPagePOSTController);
+router.get(cookiesPageRoute, cookiesGETController);
+router.post(cookiesPageRoute, cookiesPOSTController);
 
 export default router;

--- a/src/server/views/cookies/cookie-banner.html
+++ b/src/server/views/cookies/cookie-banner.html
@@ -44,12 +44,17 @@
   var rejectButton = document.getElementById("reject-analytics-cookies");
 
   function toggleAnalyticsCookies(isOn) {
-    var xhr = new XMLHttpRequest();
-    xhr.open("POST", "/help/cookies", true);
-    xhr.setRequestHeader('Content-Type', 'application/json');
-    xhr.send(JSON.stringify({
+    fetch("/help/cookies", {
+      method: "POST",
+      credentials: 'same-origin',
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
         analytics: isOn ? "on" : "off"
-    }));
+      })
+    });
   }
 
   function removeCookieBanner() {

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -52,22 +52,22 @@
 {% endblock %}
 
 {% block bodyStart %}
-  {% if isProd %}
     <script nonce="{{cspNonce}}">
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KZWHG2G" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
-    <!-- End Google Tag Manager (noscript) -->
-    
-    <!-- Google Tag Manager (noscript) -->
-    <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PCZSN93" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
-    <!-- End Google Tag Manager (noscript) -->
-  {% endif %}
+    {% if isProd %}
+      <!-- Google Tag Manager (noscript) -->
+      <noscript>
+        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KZWHG2G" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      </noscript>
+      <!-- End Google Tag Manager (noscript) -->
+      
+      <!-- Google Tag Manager (noscript) -->
+      <noscript>
+        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PCZSN93" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      </noscript>
+      <!-- End Google Tag Manager (noscript) -->
+    {% endif %}
   {% if not cookiesPolicy.isSet %}
     {% include "cookies/cookie-banner.html" %}
   {% endif %}


### PR DESCRIPTION
Adjust cookies policy to base64 encode cookie value so form-runner can parse it.
Upgrade form-runner dependency.
Minor refactoring.