### PR TITLE
fix: correct webpack config to load fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.2",
+  "version": "1.16.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.16.2",
+  "version": "1.16.3",
   "engines": {
     "node": ">=14"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,13 +73,6 @@ const client = {
           },
         ],
       },
-      {
-        test: /\.(woff|woff2|eot|ttf|otf)$/,
-        loader: "file-loader",
-        options: {
-          name: "fonts/[name].[ext]",
-        },
-      },
     ],
   },
   plugins: [


### PR DESCRIPTION
Pages which were using the Webpack generated `main.css` file were not loading up the correct fonts. This fix corrects the Webpack config in order to load those fonts.

# Before

![image](https://user-images.githubusercontent.com/53015240/134872618-8acee71d-12ba-4748-82aa-9788cf476775.png)

# After

![image](https://user-images.githubusercontent.com/53015240/134872730-8c2de91e-570f-4e86-bed7-38b6e42376d4.png)
