### PR TITLE
chore: bump version to align with GitHub tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.16.3",
+  "version": "1.16.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.16.3",
+  "version": "1.16.4",
   "engines": {
     "node": ">=14"
   },


### PR DESCRIPTION
A tag for `v1.16.3` already existed but the version was never bumped up in `package.json`. This change fixes that so that the versions all line up