### PR TITLE
fix: google tag manager content security policy

### DIFF
--- a/src/server/components/cookies/controllers.ts
+++ b/src/server/components/cookies/controllers.ts
@@ -29,7 +29,7 @@ export function cookiesPOSTController(req: Request, res: Response): void {
       secure: !isLocalHost,
       // disable encode as it breaks form-runner
       encode: (v) => v,
-      httpOnly: true,
+      httpOnly: false, // Set this to false so that Google tag manager can read cookie preferences
     }
   );
 

--- a/src/server/components/formRunner/install-form-runner.sh
+++ b/src/server/components/formRunner/install-form-runner.sh
@@ -13,12 +13,12 @@ then
   echo "Form Runner Already Installed"
 else
   echo "Installing Form Runner"
-  git clone --depth 1 --branch 3.14.2-rc.815 https://github.com/XGovFormBuilder/digital-form-builder.git $form_runner_folder
+  git clone --depth 1 --branch 3.16.1-rc.826 https://github.com/XGovFormBuilder/digital-form-builder.git $form_runner_folder
   cd $form_runner_folder
   yarn install
   yarn run build:dependencies
   yarn runner build
-  
+
   # cleanup
   rm -rf ./designer
   rm -rf ./docs
@@ -54,4 +54,3 @@ echo "Form Runner .env Created Successfully"
 # copy forms jsons
 cp -a "$forms_json_folder/." $form_runner_forms_folder
 echo "Forms JSON Files Copied Successfully"
- 

--- a/src/server/middlewares/helmet.ts
+++ b/src/server/middlewares/helmet.ts
@@ -50,6 +50,7 @@ export function configureHelmet(server: Express): void {
     helmet.contentSecurityPolicy({
       useDefaults: true,
       directives: {
+        connectSrc: [TRUSTED[0], GOOGLE_ANALYTICS_DOMAINS[0]],
         defaultSrc: [...TRUSTED, ...GOVUK_DOMAINS, ...GOOGLE_ANALYTICS_DOMAINS],
         scriptSrc: [
           generateCspNonce,
@@ -69,6 +70,7 @@ export function configureHelmet(server: Express): void {
           ...DATA,
           ...GOOGLE_STATIC_DOMAINS,
           GOOGLE_ANALYTICS_DOMAINS[3],
+          GOOGLE_ANALYTICS_DOMAINS[0],
         ],
         fontSrc: [...TRUSTED, ...DATA, ...GOOGLE_FONTS_DOMAINS],
         frameSrc: [...TRUSTED, ...DATA, GOOGLE_ANALYTICS_DOMAINS[3]],

--- a/src/server/views/layout.njk
+++ b/src/server/views/layout.njk
@@ -33,9 +33,9 @@
   <link as="font" href="/assets/fonts/light-f591b13f7d-v2.woff" type="font/woff" crossorigin="anonymous">
   <link href="/assets/accessible-autocomplete.min.css" rel="stylesheet" />
   <link type="text/css" rel="stylesheet" href="/assets/styles/main.css">
-  
+
   <meta name="Description" content="Find {{ serviceLabel if serviceLabel else "a Professional Service"}} {{ "in " + _.startCase(country) if country else "abroad"}} - GOV.UK">
-  
+
   <script src="/assets/govuk-frontend/all.js"></script>
   <script src="/assets/accessible-autocomplete.min.js"></script>
 {% endblock %}
@@ -63,7 +63,7 @@
         <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KZWHG2G" height="0" width="0" style="display:none;visibility:hidden"></iframe>
       </noscript>
       <!-- End Google Tag Manager (noscript) -->
-      
+
       <!-- Google Tag Manager (noscript) -->
       <noscript>
         <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PCZSN93" height="0" width="0" style="display:none;visibility:hidden"></iframe>


### PR DESCRIPTION
Update content security policy to allow Google Analytics to run via Google Tag Manager. Updated version of the form runner contains the same changes - see https://github.com/XGovFormBuilder/digital-form-builder/pull/714 for the changes applied there.