### PR TITLE
fix: check publish and approval states when checking if list is populated

### DIFF
--- a/src/server/models/__tests__/listItem.test.ts
+++ b/src/server/models/__tests__/listItem.test.ts
@@ -817,6 +817,8 @@ describe("ListItem Model:", () => {
 
       expect(prisma.listItem.findMany).toHaveBeenCalledWith({
         where: {
+          isApproved: true,
+          isPublished: true,
           type: ServiceType.covidTestProviders,
           address: {
             country: {

--- a/src/server/models/listItem.ts
+++ b/src/server/models/listItem.ts
@@ -451,6 +451,8 @@ export async function some(
   try {
     const result = await prisma.listItem.findMany({
       where: {
+        isApproved: true,
+        isPublished: true,
         type: serviceType,
         address: {
           country: {


### PR DESCRIPTION
The check to see if a country has any items in a list did not take into account publish state so it would stop redirecting if there were pending applications. This fix stops that from happening and will only allow you to continue your search if a country + list combination has published items.

Fixes: https://trello.com/c/DpkbZC4D/907-update-pilot-countries-in-live-find-a