### PR TITLE
fix: mapping for alternative email address for lawyers

### DIFF
--- a/src/server/components/lists/controllers.ts
+++ b/src/server/components/lists/controllers.ts
@@ -203,6 +203,7 @@ export async function listsDataIngestionController(
       const contactName = get(item.jsonData, "contactName");
       const email =
         get(item.jsonData, "contactEmailAddress") ??
+        get(item.jsonData, "publicEmailAddress") ??
         get(item.jsonData, "email") ??
         get(item.jsonData, "emailAddress");
 


### PR DESCRIPTION
lawyers use publicEmailAddress instead of contactEmailAddress, so detecting a little drift here. I've just put in another `??` statement, but we should come up with a better way of resolving this when we next add a list



