### PR TITLE
fix: ensure `queryStringFromParams` does not append extraneous ','

### DIFF
--- a/src/server/components/lists/__tests__/helpers.test.ts
+++ b/src/server/components/lists/__tests__/helpers.test.ts
@@ -34,9 +34,12 @@ describe("Lawyers List:", () => {
         propA: "a",
         propB: 1,
         propC: "c",
+        propD: ["fried", "poached", "scrambled", ""],
       };
 
-      expect(queryStringFromParams(params)).toEqual("propA=a&propB=1&propC=c");
+      expect(queryStringFromParams(params)).toEqual(
+        "propA=a&propB=1&propC=c&propD=fried,poached,scrambled"
+      );
     });
 
     test("query string is built correctly when value is preceded comma", () => {
@@ -124,7 +127,9 @@ describe("Lawyers List:", () => {
     });
 
     test("Covid test provider label is returned correctly", () => {
-      expect(getServiceLabel("covidTestProviders")).toEqual("a COVID-19 test provider");
+      expect(getServiceLabel("covidTestProviders")).toEqual(
+        "a COVID-19 test provider"
+      );
     });
 
     test("undefined is returned when service name is unknown", () => {

--- a/src/server/components/lists/helpers.ts
+++ b/src/server/components/lists/helpers.ts
@@ -29,13 +29,16 @@ export async function initLists(server: Express): Promise<void> {
 export function preProcessParams(params: { [name: string]: any }): {
   [name: string]: any;
 } {
-  let paramsCopy = { ...params };
-  const hasSelectedAll = paramsCopy?.practiceArea?.includes("All") ?? false;
-  paramsCopy = hasSelectedAll === true ? { ...paramsCopy, practiceArea: "All" } : params;
-  paramsCopy = paramsCopy?.region === "" ? { ...paramsCopy, region: "Not set"} : paramsCopy;
-  delete paramsCopy._csrf;
+  const { _csrf, ...paramsCopy } = params;
+  const hasSelectedAll: boolean =
+    paramsCopy?.practiceArea?.includes("All") ?? false;
+  const noRegionSelected = paramsCopy?.region === "";
 
-  return paramsCopy;
+  return {
+    ...paramsCopy,
+    ...(hasSelectedAll && { practiceArea: "All" }),
+    ...(noRegionSelected && { region: "Not set" }),
+  };
 }
 
 export function queryStringFromParams(
@@ -47,7 +50,7 @@ export function queryStringFromParams(
       let value: string = params[key];
 
       if (isArray(value)) {
-        value = value.toString();
+        value = value.filter(Boolean).toString();
       }
 
       if (value[0] === ",") {


### PR DESCRIPTION
**changes made**
- add filter(Boolean) to remove falsey values (including empty string)