### PR TITLE
Fixed prisma migration script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-eks: circleci/aws-eks@1.1.0
+  aws-eks: circleci/aws-eks@2.2.0
   kubernetes: circleci/kubernetes@1.0.0
   node: circleci/node@5.0.0
 

--- a/src/server/models/db/migrations/20220407103755_list_item_events_and_tags/migration.sql
+++ b/src/server/models/db/migrations/20220407103755_list_item_events_and_tags/migration.sql
@@ -1,13 +1,16 @@
 -- CreateEnum
+DROP TYPE IF EXISTS "ListItemEvent" CASCADE;
 CREATE TYPE "ListItemEvent" AS ENUM ('NEW', 'CHANGES_REQUESTED', 'EDITED', 'ANNUAL_REVIEW', 'UNPUBLISHED', 'PUBLISHED');
 
 -- CreateEnum
+DROP TYPE IF EXISTS "Status" CASCADE;
 CREATE TYPE "Status" AS ENUM ('NEW');
 
 -- AlterTable
 ALTER TABLE "ListItem" ADD COLUMN     "status" "Status" NOT NULL DEFAULT E'NEW';
 
 -- CreateTable
+DROP TABLE IF EXISTS "Event" CASCADE;
 CREATE TABLE "Event" (
     "id" SERIAL NOT NULL,
     "time" TIMESTAMP(3) NOT NULL,
@@ -19,6 +22,7 @@ CREATE TABLE "Event" (
 );
 
 -- CreateTable
+DROP TABLE IF EXISTS "_ListItemToUser" CASCADE;
 CREATE TABLE "_ListItemToUser" (
     "A" INTEGER NOT NULL,
     "B" INTEGER NOT NULL

--- a/src/server/models/db/migrations/20220419211448_list_item_audit/migration.sql
+++ b/src/server/models/db/migrations/20220419211448_list_item_audit/migration.sql
@@ -16,6 +16,9 @@ CREATE TYPE "Status" AS ENUM ('NEW','OUT_WITH_PROVIDER','EDITED','ANNUAL_REVIEW'
 -- AlterTable
 ALTER TABLE "ListItem" ADD COLUMN     "status" "Status" NOT NULL DEFAULT E'NEW';
 
+-- Update ListItem statuses
+UPDATE "ListItem" SET "status" = 'PUBLISHED' where "isPublished" = true;
+
 -- DropForeignKey
 ALTER TABLE "Event" DROP CONSTRAINT "Event_listItemId_fkey";
 

--- a/src/server/models/db/migrations/20220419211448_list_item_audit/migration.sql
+++ b/src/server/models/db/migrations/20220419211448_list_item_audit/migration.sql
@@ -8,27 +8,20 @@
 DROP TYPE IF EXISTS "AuditEvent" CASCADE;
 CREATE TYPE "AuditEvent" AS ENUM ('NEW', 'OUT_WITH_PROVIDER', 'EDITED', 'ANNUAL_REVIEW', 'REVIEWED', 'UNPUBLISHED', 'PUBLISHED', 'PINNED', 'UNPINNED', 'DELETED', 'UNDEFINED');
 
--- AlterEnum
--- This migration adds more than one value to an enum.
--- With PostgreSQL versions 11 and earlier, this is not possible
--- in a single migration. This can be worked around by creating
--- multiple migrations, each migration adding only one value to
--- the enum.
+-- CreateEnum - this type is dropped and re-created as you cannot call ALTER TYPE....ADD in postgres 11 or below.  Although using
+-- Postgres 13, the initial migration failed in prod, hence, trying another strategy.
+DROP TYPE "Status" CASCADE;
+CREATE TYPE "Status" AS ENUM ('NEW','OUT_WITH_PROVIDER','EDITED','ANNUAL_REVIEW','REVIEW_OVERDUE','REVIEWED','PUBLISHED','UNPUBLISHED');
 
-ALTER TYPE "Status" ADD VALUE 'OUT_WITH_PROVIDER';
-ALTER TYPE "Status" ADD VALUE 'EDITED';
-ALTER TYPE "Status" ADD VALUE 'ANNUAL_REVIEW';
-ALTER TYPE "Status" ADD VALUE 'REVIEW_OVERDUE';
-ALTER TYPE "Status" ADD VALUE 'REVIEWED';
-ALTER TYPE "Status" ADD VALUE 'PUBLISHED';
-ALTER TYPE "Status" ADD VALUE 'UNPUBLISHED';
+-- AlterTable
+ALTER TABLE "ListItem" ADD COLUMN     "status" "Status" NOT NULL DEFAULT E'NEW';
 
 -- DropForeignKey
 ALTER TABLE "Event" DROP CONSTRAINT "Event_listItemId_fkey";
 
 -- AlterTable
-ALTER TABLE "Audit" ADD COLUMN     "auditEvent" "AuditEvent" NOT NULL DEFAULT E'UNDEFINED';
-ALTER TABLE "Audit" ADD COLUMN     "listItemId" INTEGER;
+ALTER TABLE "Audit" ADD COLUMN     "auditEvent" "AuditEvent" NOT NULL DEFAULT E'UNDEFINED',
+ADD COLUMN     "listItemId" INTEGER;
 
 -- DropTable
 DROP TABLE "Event";

--- a/src/server/models/db/migrations/20220419211448_list_item_audit/migration.sql
+++ b/src/server/models/db/migrations/20220419211448_list_item_audit/migration.sql
@@ -5,6 +5,7 @@
 
 */
 -- CreateEnum
+DROP TYPE IF EXISTS "AuditEvent" CASCADE;
 CREATE TYPE "AuditEvent" AS ENUM ('NEW', 'OUT_WITH_PROVIDER', 'EDITED', 'ANNUAL_REVIEW', 'REVIEWED', 'UNPUBLISHED', 'PUBLISHED', 'PINNED', 'UNPINNED', 'DELETED', 'UNDEFINED');
 
 -- AlterEnum
@@ -13,7 +14,6 @@ CREATE TYPE "AuditEvent" AS ENUM ('NEW', 'OUT_WITH_PROVIDER', 'EDITED', 'ANNUAL_
 -- in a single migration. This can be worked around by creating
 -- multiple migrations, each migration adding only one value to
 -- the enum.
-
 
 ALTER TYPE "Status" ADD VALUE 'OUT_WITH_PROVIDER';
 ALTER TYPE "Status" ADD VALUE 'EDITED';
@@ -27,8 +27,8 @@ ALTER TYPE "Status" ADD VALUE 'UNPUBLISHED';
 ALTER TABLE "Event" DROP CONSTRAINT "Event_listItemId_fkey";
 
 -- AlterTable
-ALTER TABLE "Audit" ADD COLUMN     "auditEvent" "AuditEvent" NOT NULL DEFAULT E'UNDEFINED',
-ADD COLUMN     "listItemId" INTEGER;
+ALTER TABLE "Audit" ADD COLUMN     "auditEvent" "AuditEvent" NOT NULL DEFAULT E'UNDEFINED';
+ALTER TABLE "Audit" ADD COLUMN     "listItemId" INTEGER;
 
 -- DropTable
 DROP TABLE "Event";


### PR DESCRIPTION
The prisma migration script fails when run in prod due to the multiple ALTER TYPE....ADD statements.  Having multiple of these statements in the same prisma migrate scripts should only be an issue on Prisma 11 and below (we're using v13) but it still generated an error none-the-less.  These commands have been replaced with a drop, create and alter table (to add the status column back into ListItem) and it appears to execute as expected.

Release note:
The last entries from the _prisma_migrations table need to be deleted prior to the new deployment in order for the prisma deploy to succeed.