### PR TITLE
feat: smoke tests for list item actions

### DIFF
--- a/cypress/integration/management-list-item-actions.feature
+++ b/cypress/integration/management-list-item-actions.feature
@@ -1,0 +1,147 @@
+Feature:
+  Dashboard filtering
+
+  Background:
+    Given I am logged in as a "SuperAdmin"
+    And A lawyers list exists for Eurasia
+    And there are these list items
+      | contactName | organisationName  | emailAddress             | status            | isPublished | isBlocked | isApproved | emailVerified | displayedRadioButtons                     | hiddenRadioButtons                         |
+      | Winston     | Winston Law       | ali@cautionyourblast.com | NEW               | false       | false     | false      | true          | Publish,Request changes,Remove            | Unpublish,Confirm and update               |
+      | O'brien     | Brien Law         | ali@cautionyourblast.com | NEW               | false       | false     | false      | false         | Publish,Request changes,Remove            | Unpublish,Confirm and update               |
+      | Julia       | Julia Law         | ali@cautionyourblast.com | OUT_WITH_PROVIDER | false       | false     | false      | true          | Publish,Request changes,Remove            | Unpublish,Confirm and update               |
+      | Emmanuel    | Emmanuel Law      | ali@cautionyourblast.com | EDITED            | false       | false     | false      | true          | Request changes,Confirm and update,Remove | Publish,Unpublish                          |
+      | Parsons     | Parsons Law       | ali@cautionyourblast.com | PUBLISHED         | true        | false     | false      | true          | Unpublish, Remove                         | Publish,Request changes,Confirm and update |
+    Given I am viewing list item index for reference:SMOKE
+
+  # NEW
+  Scenario: list item details for NEW status
+
+    When I am viewing the list item details for "Winston"
+    Then I see radio buttons
+      | Publish | Request changes | Remove |
+    And I do not see radio buttons
+      | Unpublish | Confirm and update |
+    And The textarea should show if I select the Request changes radio button
+
+  Scenario: Request changes for list item in NEW status
+
+    When I am viewing the list item details for "Winston"
+    And The textarea should show if I select the Request changes radio button
+    And I enter a message in the textarea
+    And I click the "Continue" button
+    Then I should see the provider details "Winston", "Winston Law" and "ali@cautionyourblast.com"
+    And I click the "Request changes" button
+    Then I see the notification text "Change request sent to Winston Law"
+
+  Scenario: Publish list item in NEW status
+
+    When I am viewing the list item details for "Winston"
+    And I click the "Publish" button
+    And I click the "Publish" button
+    Then I see the notification text "Winston Law has been published"
+
+  Scenario: Remove list item in NEW status
+
+    When I am viewing the list item details for "Winston"
+    And I click the "Remove" button
+    Then I should see the provider details "Winston", "Winston Law" and "ali@cautionyourblast.com"
+    And I click the "Remove" button
+    Then I see the notification text "Winston Law has been removed"
+
+
+  # OUT_WITH_PROVIDER
+  Scenario: list item details for OUT_WITH_PROVIDER status
+
+    When I am viewing the list item details for "Julia"
+    Then I see radio buttons
+      | Publish | Request changes | Remove |
+    And I do not see radio buttons
+      | Unpublish | Confirm and update |
+    And The textarea should show if I select the Request changes radio button
+
+  Scenario: Request changes for list item in OUT_WITH_PROVIDER status
+
+    When I am viewing the list item details for "Julia"
+    And The textarea should show if I select the Request changes radio button
+    And I enter a message in the textarea
+    And I click the "Continue" button
+    Then I should see the provider details "Julia", "Julia Law" and "ali@cautionyourblast.com"
+    And I click the "Request changes" button
+    Then I see the notification text "Change request sent to Julia Law"
+
+  Scenario: Publish list item in OUT_WITH_PROVIDER status
+
+    When I am viewing the list item details for "Julia"
+    And I click the "Publish" button
+    And I click the "Publish" button
+    Then I see the notification text "Julia Law has been published"
+
+  Scenario: Remove list item in OUT_WITH_PROVIDER status
+
+    When I am viewing the list item details for "Julia"
+    And I click the "Remove" button
+    Then I should see the provider details "Julia", "Julia Law" and "ali@cautionyourblast.com"
+    And I click the "Remove" button
+    Then I see the notification text "Julia Law has been removed"
+
+
+  # EDITED
+  Scenario: list item details for EDITED status
+
+    When I am viewing the list item details for "Emmanuel"
+    Then I see radio buttons
+      | Request changes | Confirm and update | Remove |
+    And I do not see radio buttons
+      | Publish | Unpublish |
+    And The textarea should show if I select the Request changes radio button
+
+  # validate updated details are displayed
+  Scenario: Request changes for list item in EDITED status
+
+    When I am viewing the list item details for "Emmanuel"
+    And The textarea should show if I select the Request changes radio button
+    And I enter a message in the textarea
+    And I click the "Continue" button
+    Then I should see the provider details "Emmanuel", "Emmanuel Law" and "ali@cautionyourblast.com"
+    And I click the "Request changes" button
+    Then I see the notification text "Change request sent to Emmanuel Law"
+
+  Scenario: Confirm and update list item in EDITED status
+
+    When I am viewing the list item details for "Emmanuel"
+    And I click the "Confirm and update" button
+    And I click the "Update" button
+    Then I see the notification text "Emmanuel Law has been published"
+
+  Scenario: Remove list item in EDITED status
+
+    When I am viewing the list item details for "Emmanuel"
+    And I click the "Remove" button
+    Then I should see the provider details "Emmanuel", "Emmanuel Law" and "ali@cautionyourblast.com"
+    And I click the "Remove" button
+    Then I see the notification text "Emmanuel Law has been removed"
+
+
+  # PUBLISHED
+  Scenario: list item details for PUBLISHED status
+
+    When I am viewing the list item details for "Parsons"
+    Then I see radio buttons
+      | Unpublish | Remove |
+    And I do not see radio buttons
+      | Publish | Request changes | Confirm and update |
+
+  Scenario: Unpublish list item in PUBLISHED status
+
+    When I am viewing the list item details for "Parsons"
+    And I click the "Unpublish" button
+    And I click the "Unpublish" button
+    Then I see the notification text "Parsons Law has been published"
+
+  Scenario: Remove list item in PUBLISHED status
+
+    When I am viewing the list item details for "Parsons"
+    And I click the "Remove" button
+    Then I should see the provider details "Parsons", "Parsons Law" and "ali@cautionyourblast.com"
+    And I click the "Remove" button
+    Then I see the notification text "Parsons Law has been removed"

--- a/cypress/support/step_definitions/dashboard/listitems/i_am_viewing_list_item_details_for_{string}.js
+++ b/cypress/support/step_definitions/dashboard/listitems/i_am_viewing_list_item_details_for_{string}.js
@@ -1,0 +1,16 @@
+Given("I am viewing the list item details for {string}", async (contactName) => {
+  cy.task("db", {
+    operation: "listItem.findFirst",
+    variables: {
+      where: {
+        jsonData: {
+          path: ["contactName"],
+          equals: contactName
+        },
+      },
+    },
+  }).then((result) => {
+    cy.log(JSON.stringify(result));
+    cy.visit(`http://localhost:3000/dashboard/lists/${result.listId}/items/${result.id}`);
+  });
+});

--- a/cypress/support/step_definitions/dashboard/listitems/i_click_the_button_{string}.js
+++ b/cypress/support/step_definitions/dashboard/listitems/i_click_the_button_{string}.js
@@ -1,0 +1,5 @@
+And("I click the button {string}", (button) => {
+  cy.get("button")
+    .contains(button)
+    .click();
+});

--- a/cypress/support/step_definitions/dashboard/listitems/i_enter_a_message_in_the_textarea.js
+++ b/cypress/support/step_definitions/dashboard/listitems/i_enter_a_message_in_the_textarea.js
@@ -1,0 +1,4 @@
+And("I enter a message in the textarea", () => {
+  cy.get("#message")
+    .type("Please change the regulator");
+});

--- a/cypress/support/step_definitions/dashboard/listitems/i_see_radio_buttons_for_{string}.js
+++ b/cypress/support/step_definitions/dashboard/listitems/i_see_radio_buttons_for_{string}.js
@@ -1,0 +1,18 @@
+Then("I see radio buttons", (radioButtons) => {
+  const items = radioButtons.raw()[0];
+  if (Array.isArray(items)) {
+    for (const item of items) {
+      cy.findByText(item, { exact: false });
+    }
+  }
+});
+
+And("I do not see radio buttons", (radioButtons) => {
+  const items = radioButtons.raw()[0];
+  if (Array.isArray(items)) {
+    for (const item of items) {
+      cy.findByText(item, { exact: false })
+        .should("not.exist");
+    }
+  }
+});

--- a/cypress/support/step_definitions/dashboard/listitems/i_see_the_notification_text_{string}.js
+++ b/cypress/support/step_definitions/dashboard/listitems/i_see_the_notification_text_{string}.js
@@ -1,0 +1,7 @@
+Then(
+  "I see the notification text {string}",
+  (notificationText) => {
+    cy.get(".govuk-notification-banner__heading")
+      cy.findByText(notificationText);
+  }
+);

--- a/cypress/support/step_definitions/dashboard/listitems/i_see_the_relevant_radio_buttons_for_{string}.js
+++ b/cypress/support/step_definitions/dashboard/listitems/i_see_the_relevant_radio_buttons_for_{string}.js
@@ -1,0 +1,16 @@
+Given("I am viewing the list item details for {string}", async (contactName) => {
+  cy.task("db", {
+    operation: "listItem.findFirst",
+    variables: {
+      where: {
+        jsonData: {
+          path: ["contactName"],
+          equals: contactName
+        },
+      },
+    },
+  }).then((result) => {
+    cy.log("listItem.findFirst result:" + JSON.stringify(result));
+    cy.visit(`http://localhost:3000/dashboard/lists/${result.listId}/items/${result.id}`, {failOnStatusCode: false});
+  });
+});

--- a/cypress/support/step_definitions/dashboard/listitems/i_should_see_the_provider_details_{string}_{string}_and_{string}.js
+++ b/cypress/support/step_definitions/dashboard/listitems/i_should_see_the_provider_details_{string}_{string}_and_{string}.js
@@ -1,0 +1,6 @@
+Then("I should see the provider details {string}, {string} and {string}", (contactName, companyName, emailAddress) => {
+  cy.findByTestId("provider-summary")
+    .contains(contactName)
+    .contains(companyName)
+    .contains(emailAddress);
+});

--- a/cypress/support/step_definitions/dashboard/listitems/the_textbox_should_show_if_i_select_the_request_changes_radio_button.js
+++ b/cypress/support/step_definitions/dashboard/listitems/the_textbox_should_show_if_i_select_the_request_changes_radio_button.js
@@ -1,0 +1,5 @@
+And("The textarea should show if I select the Request changes radio button", () => {
+  cy.findByLabelText("Request changes")
+    .check();
+  cy.get("#message");
+});

--- a/cypress/support/step_definitions/dashboard/there_is_a_list_with_all_states.js
+++ b/cypress/support/step_definitions/dashboard/there_is_a_list_with_all_states.js
@@ -18,6 +18,20 @@ Given("A lawyers list exists for Eurasia", () => {
       },
     },
   });
+
+  cy.task("db", {
+    operation: "event.deleteMany",
+    variables: {
+      where: {
+        listItem: {
+          list: {
+            reference: "SMOKE",
+          },
+        },
+      },
+    },
+  });
+
   cy.task("db", {
     operation: "list.upsert",
     variables: {
@@ -46,16 +60,22 @@ Given("A lawyers list exists for Eurasia", () => {
 
 Given("there are these list items", (table) => {
   /**
-   * | contactName | status | isPublished | isBlocked | isApproved
+   * | contactName | companyName | status | isPublished | isBlocked | isApproved | emailVerified | isPinned | displayedRadioButtons | hiddenRadioButtons
    */
   const rows = table.hashes();
 
   const items = rows.map((row) => {
     const {
       contactName,
+      organisationName,
+      emailAddress,
       isPublished: isPublishedString,
       isApproved: isApprovedString,
       isBlocked: isBlockedString,
+      isPinned,
+      displayedRadioButtons,
+      hiddenRadioButtons,
+      emailVerified,
       ...rest
     } = row;
 
@@ -65,7 +85,18 @@ Given("there are these list items", (table) => {
 
     const jsonData = {
       contactName,
+      organisationName,
+      emailAddress,
+      metadata: {
+        emailVerified: emailVerified === "true",
+      },
+      __smoke: {
+        isPinned: isPinned === "true",
+        displayedRadioButtons: displayedRadioButtons | "",
+        hiddenRadioButtons: hiddenRadioButtons | ""
+      },
     };
+
     return listItem({
       ...rest,
       isPublished,
@@ -81,17 +112,39 @@ Given("there are these list items", (table) => {
         items: {
           createMany: { data: items, skipDuplicates: true },
         },
-        // listItems: ,
       },
       where: {
         reference: "SMOKE",
       },
+      select: {
+        items: true,
+      },
     },
+  }).then((updatedList) => {
+    const shouldPin = updatedList.items
+      .filter((item) => item.jsonData.__smoke.isPinned === true)
+      .map((item) => ({
+        id: item.id,
+      }));
+    cy.task("db", {
+      operation: "user.update",
+      variables: {
+        data: {
+          pinnedItems: {
+            set: shouldPin,
+          },
+        },
+        where: {
+          email: "smoke@cautionyourblast.com",
+        },
+      },
+    });
   });
 });
 
 function listItem(options) {
-  const { jsonData, ...rest } = options;
+  const { jsonData, isPinned, ...rest } = options;
+
   return {
     type: "lawyers",
     jsonData: {
@@ -100,17 +153,19 @@ function listItem(options) {
       proBono: true,
       regions: "France and UK",
       legalAid: true,
-      metadata: [],
+      metadata: {
+        emailVerified: jsonData.metadata.emailVerified,
+      },
       areasOfLaw: [],
       regulators: "Miniluv",
       contactName: jsonData.contactName ?? randFullName(),
       declaration: [],
       phoneNumber: "",
-      emailAddress: "ignoremyemail@noemail-ignoreme.uk",
+      emailAddress: jsonData.emailAddress ?? "ignoremyemail@noemail-ignoreme.uk",
       publishEmail: "Yes",
       speakEnglish: true,
       websiteAddress: null,
-      organisationName: randCompanyName(),
+      organisationName: jsonData.organisationName ?? randCompanyName(),
       emergencyPhoneNumber: null,
       representedBritishNationals: true,
       ...jsonData,
@@ -134,7 +189,3 @@ const status = [
   "PUBLISHED",
   "UNPUBLISHED",
 ];
-
-function listItems(numberOfItems) {
-  return new Array(numberOfItems).map(() => listItem());
-}

--- a/src/server/views/dashboard/list-item-confirm-changes.njk
+++ b/src/server/views/dashboard/list-item-confirm-changes.njk
@@ -22,7 +22,7 @@
 
     <p class="govuk-body">An email with this request will be sent to the following service provider:</p>
 
-    <p class="govuk-body">
+    <p class="govuk-body" data-testid="provider-summary">
       {{ _.startCase(_.toLower(listItem.jsonData.contactName)) }}<br/>
       {{ _.startCase(_.toLower(listItem.jsonData.organisationName if listItem.jsonData.organisationName)) }}<br/>
       {{ listItem.jsonData.emailAddress }}

--- a/src/server/views/dashboard/macros.njk
+++ b/src/server/views/dashboard/macros.njk
@@ -83,7 +83,7 @@
         {% if "request-changes" in actionButtons %}
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="action-requestChanges" name="action" type="radio" value="requestChanges" data-aria-controls="conditional-action-edit" form="mainForm">
-          <label class="govuk-label govuk-radios__label" for="action-edit">
+          <label class="govuk-label govuk-radios__label" for="action-requestChanges">
             Request changes
           </label>
         </div>


### PR DESCRIPTION
Tests cover the following:

- validation for correct radio buttons being displayed on list item details page
- validation that text box is displayed when "Request edits" checkbox is clicked on
- validation that user routed to confirmation pages plus provider summary displayed for request changes and remove actions
- validation that correct message is displayed after performing the action