### PR TITLE
fix: resolve issue with makeAddressGeoLocationString adding too much whitespace

### DIFF
--- a/src/server/models/listItem/__tests__/geoHelpers.test.ts
+++ b/src/server/models/listItem/__tests__/geoHelpers.test.ts
@@ -1,0 +1,48 @@
+import { makeAddressGeoLocationString } from "../geoHelpers";
+
+test("makeAddressGeoLocationString can construct a string from DeserialisedFormData", () => {
+  const addressWithAllLines = {
+    "address.firstLine": "70 King Charles Street",
+    "address.secondLine": "line 2",
+    city: "London",
+    postCode: "SW1A 2AH",
+    addressCountry: "Spain",
+  };
+
+  // @ts-ignore
+  expect(makeAddressGeoLocationString(addressWithAllLines)).toEqual(
+    "70 King Charles Street, line 2, London, Spain, SW1A 2AH"
+  );
+
+  const { ["address.secondLine"]: secondLine, ...addressWithNoSecondLine } = {
+    ...addressWithAllLines,
+  };
+  // @ts-ignore
+  expect(makeAddressGeoLocationString(addressWithNoSecondLine)).toEqual(
+    "70 King Charles Street, London, Spain, SW1A 2AH"
+  );
+
+  const { addressCountry, ...addressWithNoAddressCountry } =
+    addressWithAllLines;
+  const addressWithCountry = {
+    ...addressWithNoAddressCountry,
+    country: "United Kingdom",
+  };
+
+  // @ts-ignore
+  expect(makeAddressGeoLocationString(addressWithCountry)).toEqual(
+    "70 King Charles Street, line 2, London, United Kingdom, SW1A 2AH"
+  );
+
+  const addressWithWhitespace = {
+    "address.firstLine": "                             70 King Charles Street",
+    "address.secondLine": "                  line 2",
+    city: "   London                         ",
+    postCode: "                SW1A 2AH  ",
+    addressCountry: " Spain                          ",
+  };
+
+  expect(makeAddressGeoLocationString(addressWithWhitespace)).toEqual(
+    "70 King Charles Street, line 2, London, Spain, SW1A 2AH"
+  );
+});

--- a/src/server/models/listItem/geoHelpers.ts
+++ b/src/server/models/listItem/geoHelpers.ts
@@ -36,19 +36,24 @@ export async function getPlaceGeoPoint(props: {
 export function makeAddressGeoLocationString(
   webhookData: DeserialisedWebhookData
 ): string {
-  return `
-      ${webhookData["address.firstLine"] ?? ""},
-      ${webhookData["address.secondLine"] ?? ""},
-      ${webhookData.city} -
-      ${webhookData.addressCountry ?? webhookData.country} -
-      ${webhookData.postCode} ?? ""
-    `;
+  const address = [
+    webhookData["address.firstLine"],
+    webhookData["address.secondLine"],
+    webhookData.city,
+    webhookData.addressCountry ?? webhookData.country,
+    webhookData.postCode,
+  ]
+    .filter(Boolean)
+    .map((addressLine) => addressLine?.trim());
+
+  return address.join(", ");
 }
 
 export async function createAddressGeoLocation(
   item: DeserialisedWebhookData
 ): Promise<number> {
   const address = makeAddressGeoLocationString(item);
+  // TODO:- pass country into geoLocatePlaceByText so we can filter by country via AWS
   const point = await geoLocatePlaceByText(address);
 
   return await rawInsertGeoLocation(point);

--- a/src/server/services/location.ts
+++ b/src/server/services/location.ts
@@ -56,6 +56,7 @@ export async function createPlaceIndex(): Promise<boolean> {
   }
 }
 
+// TODO:- pass country into geoLocatePlaceByText so we can filter by country via AWS
 export async function geoLocatePlaceByText(
   Text: string
 ): Promise<Location.Types.Position> {


### PR DESCRIPTION
constructs the string by adding the values to an array, filtering (removing falsey values, like undefined, empty string), then iterating over them and trimming the whitespace either side `.trim()` 