### PR TITLE
chore: update country text on apply journeys

### DIFF
--- a/docker/apply/forms-json/funeral-directors.json
+++ b/docker/apply/forms-json/funeral-directors.json
@@ -1698,7 +1698,7 @@
       "title": "Post to lists",
       "type": "webhook",
       "outputConfiguration": {
-        "url": "http://host.docker.internal:3000/ingest/funeralDirectors"
+        "url": "http://lists:3000/ingest/funeralDirectors"
       }
     }
   ],

--- a/docker/apply/forms-json/funeral-directors.json
+++ b/docker/apply/forms-json/funeral-directors.json
@@ -378,7 +378,8 @@
           "type": "AutocompleteField",
           "title": "Country list",
           "list": "country",
-          "schema": {}
+          "schema": {},
+          "hint": "Select country or territory"
         },
         {
           "name": "ZoFnKT",
@@ -1697,7 +1698,7 @@
       "title": "Post to lists",
       "type": "webhook",
       "outputConfiguration": {
-        "url": "http://lists:3000/ingest/funeralDirectors"
+        "url": "http://host.docker.internal:3000/ingest/funeralDirectors"
       }
     }
   ],

--- a/docker/apply/forms-json/funeral-directors.json
+++ b/docker/apply/forms-json/funeral-directors.json
@@ -385,7 +385,7 @@
           "name": "ZoFnKT",
           "options": {},
           "type": "Html",
-          "content": "<div class=\"govuk-warning-text\">\n  <span class=\"govuk-warning-text__icon\" aria-hidden=\"true\">!</span>\n  <strong class=\"govuk-warning-text__text\">\n    <span class=\"govuk-warning-text__assistive\">Warning</span>\n    You must be based in the country you select.\n  </strong>\n</div>",
+          "content": "<div class=\"govuk-warning-text\">\n  <span class=\"govuk-warning-text__icon\" aria-hidden=\"true\">!</span>\n  <strong class=\"govuk-warning-text__text\">\n    <span class=\"govuk-warning-text__assistive\">Warning</span>\n    You must be based in the country or territory you select.\n  </strong>\n</div>",
           "schema": {}
         }
       ],

--- a/docker/apply/forms-json/lawyers.json
+++ b/docker/apply/forms-json/lawyers.json
@@ -1615,7 +1615,7 @@
       "title": "Post to lists",
       "type": "webhook",
       "outputConfiguration": {
-        "url": "http://host.docker.internal:3000/ingest/lawyers"
+        "url": "http://lists:3000/ingest/lawyers"
       }
     }
   ],

--- a/docker/apply/forms-json/lawyers.json
+++ b/docker/apply/forms-json/lawyers.json
@@ -404,7 +404,7 @@
           "name": "ZoFnKT",
           "options": {},
           "type": "Html",
-          "content": "<div class=\"govuk-warning-text\">\n  <span class=\"govuk-warning-text__icon\" aria-hidden=\"true\">!</span>\n  <strong class=\"govuk-warning-text__text\">\n    <span class=\"govuk-warning-text__assistive\">Warning</span>\n    You must be based in the country you select.\n  </strong>\n</div>"
+          "content": "<div class=\"govuk-warning-text\">\n  <span class=\"govuk-warning-text__icon\" aria-hidden=\"true\">!</span>\n  <strong class=\"govuk-warning-text__text\">\n    <span class=\"govuk-warning-text__assistive\">Warning</span>\n    You must be based in the country or territory you select.\n  </strong>\n</div>"
         }
       ],
       "next": [

--- a/docker/apply/forms-json/lawyers.json
+++ b/docker/apply/forms-json/lawyers.json
@@ -398,7 +398,7 @@
           "title": "Country list",
           "list": "country",
           "schema": {},
-          "hint": "Select country"
+          "hint": "Select country or territory"
         },
         {
           "name": "ZoFnKT",
@@ -1615,7 +1615,7 @@
       "title": "Post to lists",
       "type": "webhook",
       "outputConfiguration": {
-        "url": "http://lists:3000/ingest/lawyers"
+        "url": "http://host.docker.internal:3000/ingest/lawyers"
       }
     }
   ],

--- a/docker/apply/forms-json/translators-interpreters.json
+++ b/docker/apply/forms-json/translators-interpreters.json
@@ -2721,7 +2721,7 @@
       "title": "Post to lists",
       "type": "webhook",
       "outputConfiguration": {
-        "url": "http://host.docker.internal:3000/ingest/translators-interpreters"
+        "url": "http://lists:3000/ingest/translators-interpreters"
       }
     }
   ],

--- a/docker/apply/forms-json/translators-interpreters.json
+++ b/docker/apply/forms-json/translators-interpreters.json
@@ -385,7 +385,7 @@
           "title": "Country list",
           "list": "country",
           "schema": {},
-          "hint": "Select country"
+          "hint": "Select country or territory"
         },
         {
           "name": "ZoFnKT",
@@ -2721,7 +2721,7 @@
       "title": "Post to lists",
       "type": "webhook",
       "outputConfiguration": {
-        "url": "http://lists:3000/ingest/translators-interpreters"
+        "url": "http://host.docker.internal:3000/ingest/translators-interpreters"
       }
     }
   ],

--- a/docker/apply/forms-json/translators-interpreters.json
+++ b/docker/apply/forms-json/translators-interpreters.json
@@ -391,7 +391,7 @@
           "name": "ZoFnKT",
           "options": {},
           "type": "Html",
-          "content": "<div class=\"govuk-warning-text\">\n  <span class=\"govuk-warning-text__icon\" aria-hidden=\"true\">!</span>\n  <strong class=\"govuk-warning-text__text\">\n    <span class=\"govuk-warning-text__assistive\">Warning</span>\n    You must be based in the country you select.\n  </strong>\n</div>",
+          "content": "<div class=\"govuk-warning-text\">\n  <span class=\"govuk-warning-text__icon\" aria-hidden=\"true\">!</span>\n  <strong class=\"govuk-warning-text__text\">\n    <span class=\"govuk-warning-text__assistive\">Warning</span>\n    You must be based in the country or territory you select.\n  </strong>\n</div>",
           "schema": {}
         }
       ],

--- a/src/server/views/lists/partials/questions/question-country.njk
+++ b/src/server/views/lists/partials/questions/question-country.njk
@@ -12,6 +12,10 @@
       </span>
     {% endif %}
 
+    <div id="country-hint" class="govuk-hint">
+      Select country or territory
+    </div>
+
     <select id="country-autocomplete" name="country" className="govuk-input--error">
       <option value=""></option>
       {% for country in countriesList %}


### PR DESCRIPTION
# Description

The purpose of this ticket is to add the "Select country or territory" text to the Find and Apply journeys of this project

https://trello.com/c/j1EprHte/1089-reword-which-country-question-in-apply-and-find

## Find
<img width="994" alt="Screenshot 2022-08-01 at 18 11 36" src="https://user-images.githubusercontent.com/1377253/182205686-6ed886ac-96cf-4f17-a6d9-3fbdc10c143c.png">

## Apply
<img width="993" alt="Screenshot 2022-08-01 at 18 11 57" src="https://user-images.githubusercontent.com/1377253/182205728-ee0138f1-84c3-4455-8047-cfae6e104bca.png">
