### PR TITLE
fix: incorrect email with change request

### DIFF
--- a/src/server/components/lists/controllers/ingest/ingestPostController.ts
+++ b/src/server/components/lists/controllers/ingest/ingestPostController.ts
@@ -3,7 +3,10 @@ import { ServiceType } from "server/models/types";
 import { formRunnerPostRequestSchema } from "server/components/formRunner";
 import { createListItem } from "server/models/listItem/listItem";
 import serviceName from "server/utils/service-name";
-import { createConfirmationLink, getServiceTypeName } from "server/components/lists/helpers";
+import {
+  createConfirmationLink,
+  getServiceTypeName,
+} from "server/components/lists/helpers";
 import { sendApplicationConfirmationEmail } from "server/services/govuk-notify";
 import { logger } from "server/services/logger";
 import { ListItemJsonData } from "server/models/listItem/providers/deserialisers/types";
@@ -40,7 +43,7 @@ export async function ingestPostController(
     const { country } = address;
     const jsonData = item.jsonData as ListItemJsonData;
     const { contactName } = jsonData;
-    const email = jsonData?.publicEmailAddress ?? jsonData?.emailAddress;
+    const email = jsonData?.emailAddress;
 
     if (email === null) {
       throw new Error("No email address supplied");
@@ -57,8 +60,9 @@ export async function ingestPostController(
     );
 
     res.send({});
-  } catch (e) {
-    logger.error(`listsDataIngestionController Error: ${e.message}`);
+  } catch (error) {
+    const typedError = error as { message: string };
+    logger.error(`listsDataIngestionController Error: ${typedError.message}`);
 
     res.status(422).send({
       error: "Unable to process form",

--- a/src/server/models/listItem/__tests__/listItem.test.ts
+++ b/src/server/models/listItem/__tests__/listItem.test.ts
@@ -1218,11 +1218,11 @@ describe("ListItem Model:", () => {
     });
 
     test("contact information is correct when contactEmailAddress and contactPhoneNumber are set", () => {
-      const listItem: any = {
+      const listItem: object = {
         jsonData: {
           contactName: "ABC",
           contactPhoneNumber: "123",
-          publicEmailAddress: "123",
+          emailAddress: "123",
         },
       };
 

--- a/src/server/models/listItem/providers/helpers.ts
+++ b/src/server/models/listItem/providers/helpers.ts
@@ -168,8 +168,9 @@ export async function some(
     });
 
     return result.length > 0;
-  } catch (error) {
-    logger.error(`countryHasAnyListItem Error: ${error.message}`);
+  } catch (error: unknown) {
+    const typedError = error as { message: string };
+    logger.error(`countryHasAnyListItem Error: ${typedError.message}`);
     return false;
   }
 }
@@ -180,9 +181,7 @@ export function getListItemContactInformation(listItem: ListItem): {
   contactPhoneNumber: string;
 } {
   const contactName = get(listItem?.jsonData, "contactName");
-  const contactEmailAddress =
-    get(listItem?.jsonData, "publicEmailAddress") ??
-    get(listItem?.jsonData, "emailAddress");
+  const contactEmailAddress = get(listItem?.jsonData, "emailAddress");
   const contactPhoneNumber =
     get(listItem?.jsonData, "contactPhoneNumber") ??
     get(listItem?.jsonData, "phoneNumber");


### PR DESCRIPTION
# Description

The purpose of this PR is to make sure that when an email is sent out to a lawyer(or another profession) requesting a change to their listing, the email is sent to their **PRIVATE** email account and not their **PUBLIC** one.

Ticket: https://trello.com/c/kPMU9v3A/1299-list-management-request-edit-not-sending-to-admin-email

This only applies to lawyers who have both a public and private email in their account.

As I am not able to test this end-to-end locally:
<img width="634" alt="Screenshot 2022-08-03 at 17 39 18" src="https://user-images.githubusercontent.com/1377253/182662804-4a8db3a3-c218-493d-a6b3-0cec26325bf4.png">

---

I created a console log to see what the function that fetches the email address is outputting:
<img width="1163" alt="Screenshot 2022-08-03 at 17 28 33" src="https://user-images.githubusercontent.com/1377253/182662903-71483c3d-3c0c-46bf-8dfe-7fbbec5b19c7.png">

---

As you will see in [this pull request](https://github.com/UKForeignOffice/lists/pull/429), this specific listing has both a public and private email. It's just not showing in the second screenshot because that fix is on PR #429 and hasn't yet been merged in.