### PR TITLE
chore: make postocde field optinal for lawyers

### DIFF
--- a/docker/apply/forms-json/lawyers.json
+++ b/docker/apply/forms-json/lawyers.json
@@ -137,7 +137,9 @@
         },
         {
           "name": "postCode",
-          "options": {},
+          "options": {
+            "required": false
+          },
           "type": "TextField",
           "title": "Post code / area code",
           "schema": {}


### PR DESCRIPTION
# Description

The purpose of this PR is to make the postcode field optional for the apply process for lawyers

Ticket: https://trello.com/c/hVBWvUlL/1130-lawyers-apply-journey-make-postcode-optional

<img width="869" alt="Screenshot 2022-08-04 at 15 46 53" src="https://user-images.githubusercontent.com/1377253/182876900-713e306d-d8f1-423d-8427-de395474a1ef.png">
