### PR TITLE
chore: add back button for list managment details

### DIFF
--- a/src/client/styles/styles.scss
+++ b/src/client/styles/styles.scss
@@ -18,13 +18,13 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
   display: flex;
   line-height: 1.25;
   justify-content: space-between;
-  font-family: "GDS Transport",arial,sans-serif;
+  font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
   font-size: 1.1875rem;
   text-align: justify;
-  content: '';
+  content: "";
 
   &__list-items {
     list-style: none;
@@ -161,7 +161,6 @@ main.govuk-main-wrapper {
   }
 }
 
-
 $one-third: math.div(1, 3) * 100%;
 $two-thirds: $one-third * 2;
 
@@ -219,6 +218,21 @@ $two-thirds: $one-third * 2;
   &__list-item-caption {
     position: relative;
   }
+}
 
+.back-links {
+  &__container {
+    display: flex;
+  }
 
+  &__aside {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  &__item {
+    width: 100%;
+  }
 }

--- a/src/server/views/dashboard/dashboard.njk
+++ b/src/server/views/dashboard/dashboard.njk
@@ -6,8 +6,8 @@
     <a href="/logout" class="govuk-link">Logout</a>
   </div>
   <div class="govuk-width-container dashboard__container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
+    <div class="govuk-grid-row back-links__container">
+      <div class="govuk-grid-column-one-quarter back-links__aside">
         {% block aside %}
         <nav class="govuk-!-padding-top-7 govuk-!-padding-bottom-7">
           <ul class="govuk-list">

--- a/src/server/views/dashboard/lists-item.njk
+++ b/src/server/views/dashboard/lists-item.njk
@@ -2,7 +2,12 @@
 {% import "./macros.njk" as dashboardMacros %}
 
 {% block aside %}
-  <a class="govuk-link govuk-back-link" href="{{ dashboardRoutes.listsItems.replace(':listId', list.id) }}">Back</a>
+  <div class="back-links__item">
+    <a class="govuk-link govuk-back-link" href="{{ dashboardRoutes.listsItems.replace(':listId', list.id) }}">Back</a>
+  </div>
+  <div class="back-links__item">
+    <a class="govuk-link govuk-back-link" href="{{ dashboardRoutes.listsItems.replace(':listId', list.id) }}">Back</a>
+  </div>
 {% endblock %}
 
 {% block dashboard %}

--- a/src/server/views/dashboard/macros.njk
+++ b/src/server/views/dashboard/macros.njk
@@ -126,13 +126,6 @@
         "data-id": listItem.id
       }
     }) }}
-
-    {{ govukButton({
-      text: "Back",
-      type: "button",
-      href: dashboardRoutes.listsItems.replace(':listId', list.id),
-      classes: "govuk-button--secondary"
-    }) }}
   </div>
 
 </div>

--- a/src/server/views/dashboard/macros.njk
+++ b/src/server/views/dashboard/macros.njk
@@ -126,6 +126,13 @@
         "data-id": listItem.id
       }
     }) }}
+
+    {{ govukButton({
+      text: "Back",
+      type: "button",
+      href: dashboardRoutes.listsItems.replace(':listId', list.id),
+      classes: "govuk-button--secondary"
+    }) }}
   </div>
 
 </div>


### PR DESCRIPTION
# Description

The purpose of this PR is to add a back button to the bottom of the list management page

Ticket: https://trello.com/c/8awKrp25/1360-all-list-management-add-a-back-button-in-list-item-details-page

_NOTE: No designed have been provided for this ticket so I've sort of made things up. I have informed Anna_

https://user-images.githubusercontent.com/1377253/182887296-bc426368-4c15-4a0d-be4e-ff82ff20cb6b.mp4


## Updated feature 👇


https://user-images.githubusercontent.com/1377253/184906049-f78c7501-b205-4fbf-979f-6ce2a8e3e114.mp4


