### PR TITLE
chore: persist change request text on cancellation

### DIFF
--- a/src/server/components/dashboard/listsItems/controllers.ts
+++ b/src/server/components/dashboard/listsItems/controllers.ts
@@ -139,7 +139,7 @@ export async function listItemGetController(
   const actionButtonsForStatus = actionButtons[listItem.status];
   res.render("dashboard/lists-item", {
     ...DEFAULT_VIEW_PROPS,
-    req,
+    changeMessage: req.session?.changeMessage,
     list,
     listItem,
     isPinned,

--- a/src/server/components/dashboard/listsItems/controllers.ts
+++ b/src/server/components/dashboard/listsItems/controllers.ts
@@ -501,7 +501,7 @@ export async function listItemRequestChangeController(
       listItem,
       changeMessage,
       userId,
-      isUnderTest,
+      isUnderTest
     );
 
     req.flash(
@@ -511,6 +511,8 @@ export async function listItemRequestChangeController(
     req.flash("successBannerHeading", "Requested");
     req.flash("successBannerColour", "blue");
     res.redirect(dashboardRoutes.listsItems.replace(":listId", listId));
+
+    req.session.changeMessage = undefined;
   } catch (error: any) {
     req.flash(
       "errorMsg",
@@ -529,7 +531,7 @@ async function handleListItemRequestChanges(
   listItem: ListItemGetObject,
   message: string,
   userId: User["id"],
-  isUnderTest: boolean,
+  isUnderTest: boolean
 ): Promise<void> {
   if (userId === undefined) {
     throw new Error("handleListItemRequestChange Error: userId is undefined");
@@ -542,11 +544,15 @@ async function handleListItemRequestChanges(
   );
 
   // Email applicant
-  logger.info(`Generated form runner URL [${formRunnerEditUserUrl}], getting list item contact info.`)
+  logger.info(
+    `Generated form runner URL [${formRunnerEditUserUrl}], getting list item contact info.`
+  );
   const { contactName, contactEmailAddress } =
     getListItemContactInformation(listItem);
 
-  logger.info(`Got contact info [${contactName}, ${contactEmailAddress}], getting list item contact info.`)
+  logger.info(
+    `Got contact info [${contactName}, ${contactEmailAddress}], getting list item contact info.`
+  );
   const listType = serviceName(list?.type ?? "");
 
   logger.info(`Got list type [${listType}`);
@@ -698,7 +704,7 @@ async function initialiseFormRunnerSession(
   const questions = await generateFormRunnerWebhookData(
     list,
     listItem,
-    isUnderTest,
+    isUnderTest
   );
   const formRunnerWebhookData = getNewSessionWebhookData(
     list.type,

--- a/src/server/components/dashboard/listsItems/controllers.ts
+++ b/src/server/components/dashboard/listsItems/controllers.ts
@@ -511,8 +511,6 @@ export async function listItemRequestChangeController(
     req.flash("successBannerHeading", "Requested");
     req.flash("successBannerColour", "blue");
     res.redirect(dashboardRoutes.listsItems.replace(":listId", listId));
-
-    req.session.changeMessage = undefined;
   } catch (error: any) {
     req.flash(
       "errorMsg",

--- a/src/server/components/dashboard/listsItems/listItemsIndexController.ts
+++ b/src/server/components/dashboard/listsItems/listItemsIndexController.ts
@@ -97,6 +97,7 @@ export async function listItemsIndexController(
     const { listId } = req.params;
     const sanitisedQueryParams = sanitiseListItemsQueryParams(req.query);
     const { tag: queryTag, page } = sanitisedQueryParams;
+    req.session.changeMessage = undefined;
 
     const list = await findIndexListItems({
       listId: Number(listId),

--- a/src/server/views/dashboard/list-item-confirm-changes.njk
+++ b/src/server/views/dashboard/list-item-confirm-changes.njk
@@ -2,6 +2,9 @@
 {% extends "./dashboard.njk" %}
 
 {% block aside %}
+  <div class="back-links__item">
+    <a class="govuk-link govuk-back-link" href="{{ dashboardRoutes.listsItem.replace(':listId', list.id).replace(':listItemId', listItem.id) }}">Back</a>
+  </div>
 {% endblock %}
 
 {% block dashboard %}

--- a/src/server/views/dashboard/lists-item.njk
+++ b/src/server/views/dashboard/lists-item.njk
@@ -33,7 +33,7 @@
       <div class="govuk-list dashboard__content-list">
           <div id="item-{{ listItem.id }}">
             {% include "./partials/details.njk" %}
-            {{ dashboardMacros.listItemEditActionBar(list, listItem, dashboardRoutes, listItem.jsonData.contactName, isPinned, actionButtons, req) }}
+            {{ dashboardMacros.listItemEditActionBar(list, listItem, dashboardRoutes, listItem.jsonData.contactName, isPinned, actionButtons, changeMessage) }}
           </div>
       </div>
     </form>

--- a/src/server/views/dashboard/lists-item.njk
+++ b/src/server/views/dashboard/lists-item.njk
@@ -33,16 +33,21 @@
       <div class="govuk-list dashboard__content-list">
           <div id="item-{{ listItem.id }}">
             {% include "./partials/details.njk" %}
-            {{ dashboardMacros.listItemEditActionBar(list, listItem, dashboardRoutes, listItem.jsonData.contactName, isPinned, actionButtons) }}
+            {{ dashboardMacros.listItemEditActionBar(list, listItem, dashboardRoutes, listItem.jsonData.contactName, isPinned, actionButtons, req) }}
           </div>
       </div>
     </form>
 
     <script nonce="{{cspNonce}}">
-
       const hiddenClass = "govuk-radios__conditional--hidden";
-      document.querySelector("#conditional-action-requestChanges").classList.add(hiddenClass);
       const radios = document.querySelectorAll('input[type=radio][name="action"]');
+      const radiosArray = Array.from(radios);
+      const requestChangesRadioBtn = radiosArray.find(radio => radio.value === "requestChanges");
+
+      if (requestChangesRadioBtn && !requestChangesRadioBtn.checked) {
+        document.getElementById("conditional-action-requestChanges").classList.add(hiddenClass);
+      }
+
       radios.forEach(radio => radio.addEventListener('change', () => {
         const isRequestingChanges = radio.value === "requestChanges" && radio.checked;
         const requestChangesTextarea = document.getElementById("conditional-action-requestChanges");

--- a/src/server/views/dashboard/macros.njk
+++ b/src/server/views/dashboard/macros.njk
@@ -53,7 +53,7 @@
   </div>
 {% endmacro %}
 
-{% macro listItemEditActionBar(list, listItem, dashboardRoutes, titleProperty, isPinned, actionButtons, req) %}
+{% macro listItemEditActionBar(list, listItem, dashboardRoutes, titleProperty, isPinned, actionButtons, changeMessage) %}
 
   <div class="govuk-!-margin-top-8">
   <div class="govuk-form-group">
@@ -82,7 +82,7 @@
         {% endif %}
         {% if "request-changes" in actionButtons %}
         <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="action-requestChanges" name="action" type="radio" value="requestChanges" data-aria-controls="conditional-action-edit" form="mainForm" {% if req.session.changeMessage %} checked {% endif %}>
+          <input class="govuk-radios__input" id="action-requestChanges" name="action" type="radio" value="requestChanges" data-aria-controls="conditional-action-edit" form="mainForm" {% if changeMessage %} checked {% endif %}>
           <label class="govuk-label govuk-radios__label" for="action-requestChanges">
             Request changes
           </label>
@@ -92,7 +92,7 @@
             <div id="action-edit-hint" class="govuk-hint">
               Provide simple and concise instructions to the service provider on what they need to change.
             </div>
-            <textarea class="govuk-textarea" id="message" name="message" rows="5" aria-describedby="action-requestChanges-hint">{{ req.session.changeMessage if req.session.changeMessage }}</textarea>
+            <textarea class="govuk-textarea" id="message" name="message" rows="5" aria-describedby="action-requestChanges-hint">{{ changeMessage if changeMessage }}</textarea>
           </div>
         </div>
         {% endif %}

--- a/src/server/views/dashboard/macros.njk
+++ b/src/server/views/dashboard/macros.njk
@@ -53,7 +53,7 @@
   </div>
 {% endmacro %}
 
-{% macro listItemEditActionBar(list, listItem, dashboardRoutes, titleProperty, isPinned, actionButtons) %}
+{% macro listItemEditActionBar(list, listItem, dashboardRoutes, titleProperty, isPinned, actionButtons, req) %}
 
   <div class="govuk-!-margin-top-8">
   <div class="govuk-form-group">
@@ -82,7 +82,7 @@
         {% endif %}
         {% if "request-changes" in actionButtons %}
         <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="action-requestChanges" name="action" type="radio" value="requestChanges" data-aria-controls="conditional-action-edit" form="mainForm">
+          <input class="govuk-radios__input" id="action-requestChanges" name="action" type="radio" value="requestChanges" data-aria-controls="conditional-action-edit" form="mainForm" {% if req.session.changeMessage %} checked {% endif %}>
           <label class="govuk-label govuk-radios__label" for="action-requestChanges">
             Request changes
           </label>
@@ -92,7 +92,7 @@
             <div id="action-edit-hint" class="govuk-hint">
               Provide simple and concise instructions to the service provider on what they need to change.
             </div>
-            <textarea class="govuk-textarea" id="message" name="message" rows="5" aria-describedby="action-requestChanges-hint"></textarea>
+            <textarea class="govuk-textarea" id="message" name="message" rows="5" aria-describedby="action-requestChanges-hint">{{ req.session.changeMessage if req.session.changeMessage }}</textarea>
           </div>
         </div>
         {% endif %}


### PR DESCRIPTION
# Description

The purpose of this ticket is to allow users to see the information they've typed in, after requesting changes , then pressing the back button.

This ticket also adds a back button to the top of the request changes page.

Ticket: https://trello.com/c/ljH69Snw/1401-list-management-build-a-back-button-and-or-cancel-to-let-users-edit-the-change-request-box

https://user-images.githubusercontent.com/1377253/186893203-b1c5f583-1b2d-482d-a439-5ea9e370c9be.mp4


