### PR TITLE
fix: show public emails if they exist

### DIFF
--- a/src/server/views/lists/partials/funeral-directors/macros.njk
+++ b/src/server/views/lists/partials/funeral-directors/macros.njk
@@ -87,7 +87,13 @@
   </p>
   {% if item.jsonData.emailAddress %}
     <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-      <strong>Email</strong>: <a class="govuk-link" href="mailto:{{ item.jsonData.emailAddress }}">{{ item.jsonData.emailAddress }}</a>
+      <strong>Email</strong>:
+      <a
+        class="govuk-link"
+        href="mailto:{{ item.jsonData.publicEmailAddress if item.jsonData.publicEmailAddress else item.jsonData.emailAddress }}"
+      >
+        {{ item.jsonData.publicEmailAddress if item.jsonData.publicEmailAddress else item.jsonData.emailAddress }}
+      </a>
     </p>
   {% endif %}
   {% if item.jsonData.phoneNumber %}

--- a/src/server/views/lists/partials/funeral-directors/macros.njk
+++ b/src/server/views/lists/partials/funeral-directors/macros.njk
@@ -73,11 +73,6 @@
   <h3 class="govuk-heading-s govuk-!-margin-bottom-4">
     Contact details
   </h3>
-  {% if item.jsonData.contactName %}
-    <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-      <strong>{{ _.startCase(_.toLower(item.jsonData.contactName)) }}</strong>
-    </p>
-  {% endif %}
   <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
     <strong>Address</strong>:
       {{ item.address.firstLine }}

--- a/src/server/views/lists/partials/lawyers/macros.njk
+++ b/src/server/views/lists/partials/lawyers/macros.njk
@@ -74,7 +74,13 @@
   </p>
   {% if item.jsonData.emailAddress %}
     <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-      <strong>Email</strong>: <a class="govuk-link" href="mailto:{{ item.jsonData.emailAddress }}">{{ item.jsonData.emailAddress }}</a>
+      <strong>Email</strong>:
+      <a
+        class="govuk-link"
+        href="mailto:{{ item.jsonData.publicEmailAddress if item.jsonData.publicEmailAddress else item.jsonData.emailAddress }}"
+      >
+        {{ item.jsonData.publicEmailAddress if item.jsonData.publicEmailAddress else item.jsonData.emailAddress }}
+      </a>
     </p>
   {% endif %}
   {% if item.jsonData.phoneNumber %}

--- a/src/server/views/lists/partials/translators-interpreters/macros.njk
+++ b/src/server/views/lists/partials/translators-interpreters/macros.njk
@@ -29,11 +29,6 @@
       {{ (item.distanceinmeters / 1609).toFixed(1) }} miles
     </span>
   {% endif %}
-  {% if item.jsonData.contactName %}
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-4">
-      {{ _.startCase(_.toLower(item.jsonData.contactName)) }}
-    </h2>
-  {% endif %}
   <h3 class="govuk-heading-s govuk-!-margin-bottom-4">
     {% if item.jsonData.websiteAddress %}
         <a class="govuk-link" href="{{ item.jsonData.websiteAddress }}" rel="noopener noreferrer" target="_blank">{{ _.startCase(_.toLower(item.jsonData.organisationName if item.jsonData.organisationName)) }}</a>
@@ -80,11 +75,6 @@
   <h3 class="govuk-heading-s govuk-!-margin-bottom-4">
     Contact details
   </h3>
-  {% if item.jsonData.contactName %}
-    <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-      <strong>Contact name</strong>: {{ _.startCase(_.toLower(item.jsonData.contactName)) }}
-    </p>
-  {% endif %}
   <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
     <strong>Address</strong>:
     {% if item.jsonData.addressDisplay === "partial" %}

--- a/src/server/views/lists/partials/translators-interpreters/macros.njk
+++ b/src/server/views/lists/partials/translators-interpreters/macros.njk
@@ -104,7 +104,13 @@
 
   {% if emailAddress %}
     <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-      <strong>Email</strong>: <a class="govuk-link" href="mailto:{{ emailAddress }}">{{ emailAddress }}</a>
+      <strong>Email</strong>:
+      <a
+        class="govuk-link"
+        href="mailto:{{ item.jsonData.publicEmailAddress if item.jsonData.publicEmailAddress else item.jsonData.emailAddress }}"
+      >
+        {{ item.jsonData.publicEmailAddress if item.jsonData.publicEmailAddress else item.jsonData.emailAddress }}
+      </a>
     </p>
   {% endif %}
   {% if item.jsonData.phoneNumber %}
@@ -167,4 +173,3 @@
     </div>
   {% endif %}
 {% endmacro %}
-


### PR DESCRIPTION
# Description

The purpose of this pull request is to show public emails if they exist or show the private email address

Trello ticket: https://trello.com/c/synPjNkb/1507-%F0%9F%9A%A8-p1-investigation-russia-funeral-list-publishing-private-funeral-director-content-in-error
