### PR TITLE
fix: change priority of "check edits" and "removed by post" vs "requested edits"

### DIFF
--- a/src/server/components/dashboard/listsItems/controllers.ts
+++ b/src/server/components/dashboard/listsItems/controllers.ts
@@ -319,7 +319,7 @@ export async function handleListItemUpdate(id: number, userId: User["id"]): Prom
     await update(id, userId, auditJsonData.updatedJsonData);
   }
 
-  if (!!auditJsonData?.updatedJsonData) {
+  if (auditJsonData?.updatedJsonData) {
     await update(id, userId);
   }
 }

--- a/src/server/components/dashboard/listsItems/controllers.ts
+++ b/src/server/components/dashboard/listsItems/controllers.ts
@@ -299,6 +299,7 @@ export async function handleListItemUpdate(id: number, userId: User["id"]): Prom
       },
     },
   });
+
   if (listItem === null) {
     logger.error(`${userId} tried to look for ${id}, listItem could not be found`);
     throw new Error(`Unable to store updates - listItem could not be found`);
@@ -306,9 +307,9 @@ export async function handleListItemUpdate(id: number, userId: User["id"]): Prom
 
   const editEvent = listItem?.history.find((event) => {
     // @ts-ignore
-    return event.type === ListItemEvent.EDITED && event.jsonData;
+    return event.type === ListItemEvent.EDITED && !!event.jsonData?.updatedJsonData;
   });
-  logger.info(`${userId} found ${JSON.stringify(listItem)}`);
+
   logger.info(`found edit event ${JSON.stringify(editEvent)}`);
 
   const auditJsonData: EventJsonData = editEvent?.jsonData as EventJsonData;
@@ -316,6 +317,10 @@ export async function handleListItemUpdate(id: number, userId: User["id"]): Prom
   if (auditJsonData?.updatedJsonData !== undefined) {
     // @ts-ignore
     await update(id, userId, auditJsonData.updatedJsonData);
+  }
+
+  if (!!auditJsonData?.updatedJsonData) {
+    await update(id, userId);
   }
 }
 

--- a/src/server/components/dashboard/listsItems/controllers.ts
+++ b/src/server/components/dashboard/listsItems/controllers.ts
@@ -302,7 +302,7 @@ export async function handleListItemUpdate(id: number, userId: User["id"]): Prom
     throw new Error(`Unable to store updates - listItem could not be found`);
   }
 
-  const editEvent = listItem?.history.find((event) => event.type === "EDITED");
+  const editEvent = listItem?.history.find((event) => event.type === "EDITED" && event.jsonData?.updatedJsonData);
 
   const auditJsonData: EventJsonData = editEvent?.jsonData as EventJsonData;
 

--- a/src/server/components/lists/controllers/ingest/ingestPutController.ts
+++ b/src/server/components/lists/controllers/ingest/ingestPutController.ts
@@ -22,7 +22,7 @@ export async function ingestPutController(req: Request, res: Response) {
     return;
   }
 
-  if (!!error) {
+  if (error) {
     res.status(422).json({ error: error.message });
     return;
   }

--- a/src/server/components/lists/controllers/ingest/ingestPutController.ts
+++ b/src/server/components/lists/controllers/ingest/ingestPutController.ts
@@ -8,25 +8,21 @@ import { DeserialisedWebhookData } from "server/models/listItem/providers/deseri
 import { ServiceType } from "server/models/types";
 import { deserialise } from "server/models/listItem/listItemCreateInputFromWebhook";
 import { getServiceTypeName } from "server/components/lists/helpers";
-import {EVENTS} from "server/models/listItem/listItemEvent";
+import { EVENTS } from "server/models/listItem/listItemEvent";
 
-export async function ingestPutController(
-  req: Request,
-  res: Response
-): Promise<void> {
+export async function ingestPutController(req: Request, res: Response) {
   const id = req.params.id;
   const serviceType = getServiceTypeName(req.params.serviceType) as ServiceType;
   const { value, error } = formRunnerPostRequestSchema.validate(req.body);
 
   if (!serviceType || !(serviceType in ServiceType)) {
     res.status(500).json({
-      error:
-        "serviceType is incorrect, please make sure form's webhook output configuration is correct",
+      error: "serviceType is incorrect, please make sure form's webhook output configuration is correct",
     });
     return;
   }
 
-  if (error !== undefined) {
+  if (!!error) {
     res.status(422).json({ error: error.message });
     return;
   }
@@ -39,21 +35,10 @@ export async function ingestPutController(
 
   try {
     data = deserialise(value);
-
   } catch (e) {
     res.status(422).json({ error: "questions could not be deserialised" });
     return;
   }
-
-  const listItemPrismaQuery: Prisma.ListItemUpdateArgs = {
-    where: { id: Number(id) },
-    data: {
-      status: Status.EDITED,
-      history: {
-        create: EVENTS.EDITED(data)
-      }
-    },
-  };
 
   try {
     const listItem = await prisma.listItem.findUnique({
@@ -62,13 +47,32 @@ export async function ingestPutController(
         history: true,
       },
     });
-    if (listItem === undefined) {
-      res.status(404).send({
+
+    if (listItem === null) {
+      return res.status(404).send({
         error: {
           message: `Unable to store updates - listItem could not be found`,
         },
       });
     }
+
+    const jsonData = listItem.jsonData as Prisma.JsonObject;
+    const jsonDataWithUpdatedJsonData = {
+      ...jsonData,
+      updatedJsonData: data,
+    };
+
+    const listItemPrismaQuery: Prisma.ListItemUpdateArgs = {
+      where: { id: Number(id) },
+      data: {
+        status: Status.EDITED,
+        history: {
+          create: EVENTS.EDITED(data),
+        },
+        jsonData: jsonDataWithUpdatedJsonData,
+      },
+    };
+
     await prisma.$transaction([
       prisma.listItem.update(listItemPrismaQuery),
       recordListItemEvent(
@@ -88,6 +92,6 @@ export async function ingestPutController(
      * TODO:- Queue?
      */
 
-    res.status(422).send({ message: "List item failed to update" });
+    return res.status(422).send({ message: "List item failed to update" });
   }
 }

--- a/src/server/models/db/migrations/20221125163439_allow_cascading_deletes/migration.sql
+++ b/src/server/models/db/migrations/20221125163439_allow_cascading_deletes/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Event" DROP CONSTRAINT "Event_listItemId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Event" ADD FOREIGN KEY ("listItemId") REFERENCES "ListItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/server/models/db/schema.prisma
+++ b/src/server/models/db/schema.prisma
@@ -151,7 +151,7 @@ enum Status {
 model Event {
   id                  Int    @id @default(autoincrement())
   time                DateTime @default(now())
-  listItem            ListItem? @relation(fields: [listItemId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  listItem            ListItem? @relation(fields: [listItemId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   listItemId          Int
   type                ListItemEvent
   jsonData            Json

--- a/src/server/models/listItem/__tests__/summary.helpers.test.ts
+++ b/src/server/models/listItem/__tests__/summary.helpers.test.ts
@@ -1,30 +1,28 @@
 import {
   getActivityStatus,
-  getPublishingStatus, hasBeenPublishedSinceUnpublishing,
+  getPublishingStatus,
+  hasBeenPublishedSinceUnpublishing,
   hasBeenUnpublishedSincePublishing,
-  wasUnpublishedByUser
+  wasUnpublishedByUser,
 } from "./../summary.helpers";
 
-
 test("wasUnpublishedByUser returns true if userId is present", () => {
-
   const noUserHistory = [
     {
       type: "UNPUBLISHED",
-      time: new Date("2022-02-02")
-    }
+      time: new Date("2022-02-02"),
+    },
   ];
   expect(wasUnpublishedByUser(noUserHistory)).toBe(false);
-
 
   const withUserHistory = [
     {
       type: "UNPUBLISHED",
       time: new Date("2022-02-02"),
       jsonData: {
-        userId: 366
-      }
-    }
+        userId: 366,
+      },
+    },
   ];
   expect(wasUnpublishedByUser(withUserHistory)).toBe(true);
 
@@ -33,10 +31,10 @@ test("wasUnpublishedByUser returns true if userId is present", () => {
       type: "UNPUBLISHED",
       time: new Date("2022-02-02"),
       jsonData: {
-        userId: 0
-      }
-    }
-  ]
+        userId: 0,
+      },
+    },
+  ];
   expect(wasUnpublishedByUser(withFalseyIntUserHistory)).toBe(true);
 
   const withTruthyIntUserHistory = [
@@ -44,75 +42,76 @@ test("wasUnpublishedByUser returns true if userId is present", () => {
       type: "UNPUBLISHED",
       time: new Date("2022-02-02"),
       jsonData: {
-        userId: 1
-      }
-    }
-  ]
+        userId: 1,
+      },
+    },
+  ];
   expect(wasUnpublishedByUser(withTruthyIntUserHistory)).toBe(true);
-})
+});
 
 test("getActivityStatus returns the correct status that does not have historical dependencies", () => {
   const item = {
     history: [],
     isPublished: true,
-    isAnnualReview: false
-  }
+    isAnnualReview: false,
+  };
 
   const newItem = {
     ...item,
-    status: "NEW"
-  }
-  expect(getActivityStatus(newItem).text).toBe("Check new entry")
+    status: "NEW",
+  };
+  expect(getActivityStatus(newItem).text).toBe("Check new entry");
 
   const editedItem = {
     ...item,
-    status: "EDITED"
-  }
-  expect(getActivityStatus(editedItem).text).toBe("Check edits")
+    status: "EDITED",
+  };
+  expect(getActivityStatus(editedItem).text).toBe("Check edits");
 
   const publishedItem = {
     ...item,
-    status: "PUBLISHED"
-  }
-  expect(getActivityStatus(publishedItem).text).toBe("No action needed")
+    status: "PUBLISHED",
+  };
+  expect(getActivityStatus(publishedItem).text).toBe("No action needed");
 
   const withProviderItem = {
     ...item,
-    status: "OUT_WITH_PROVIDER"
-  }
-  expect(getActivityStatus(withProviderItem).text).toBe("Edits requested")
+    status: "OUT_WITH_PROVIDER",
+  };
+  expect(getActivityStatus(withProviderItem).text).toBe("Edits requested");
 
   const overdueItem = {
     ...item,
-    status: "ANNUAL_REVIEW_OVERDUE"
-  }
-  expect(getActivityStatus(overdueItem).text).toBe("Annual review overdue")
+    status: "ANNUAL_REVIEW_OVERDUE",
+  };
+  expect(getActivityStatus(overdueItem).text).toBe("Annual review overdue");
 
   const checkItem = {
     ...item,
-    status: "CHECK_ANNUAL_REVIEW"
-  }
-  expect(getActivityStatus(checkItem).text).toBe("Check annual review")
+    status: "CHECK_ANNUAL_REVIEW",
+  };
+  expect(getActivityStatus(checkItem).text).toBe("Check annual review");
 });
 
 test("getActivityStatus returns removed by post if a provider has been unpublished", () => {
-  const history = [{
+  const history = [
+    {
       type: "PUBLISHED",
-      time: new Date("2022-01-01")
+      time: new Date("2022-01-01"),
     },
-      {
-        type: "UNPUBLISHED",
-        time: new Date("2022-02-02")
-      }
-    ];
+    {
+      type: "UNPUBLISHED",
+      time: new Date("2022-02-02"),
+    },
+  ];
   const item = {
     status: "UNPUBLISHED",
     isPublished: false,
     history,
-    isAnnualReview: false
-  }
+    isAnnualReview: false,
+  };
 
-  expect(getActivityStatus(item).text).toBe("Removed by post")
+  expect(getActivityStatus(item).text).toBe("Removed by post");
 
   const itemUnpublishedWithUser = {
     ...item,
@@ -122,12 +121,29 @@ test("getActivityStatus returns removed by post if a provider has been unpublish
         type: "UNPUBLISHED",
         time: new Date("2022-02-02"),
         jsonData: {
-          userId: 366
-        }
-    }]
-  }
+          userId: 366,
+        },
+      },
+    ],
+  };
 
-  expect(getActivityStatus(itemUnpublishedWithUser).text).toBe("Removed by post")
+  expect(getActivityStatus(itemUnpublishedWithUser).text).toBe("Removed by post");
+
+  const itemRemovedByPostButEditsRequested = {
+    ...item,
+    status: "OUT_WITH_PROVIDER",
+    history: [
+      history[0],
+      {
+        type: "UNPUBLISHED",
+        time: new Date("2022-02-02"),
+        jsonData: {
+          userId: 366,
+        },
+      },
+    ],
+  };
+  expect(getActivityStatus(itemRemovedByPostButEditsRequested).text).toBe("Edits requested");
 
   //NOTE:- currently the only other instance of unpublishing is due to scheduled annual review.
 });
@@ -136,34 +152,35 @@ test("getPublishingStatus returns the correct publishing status", () => {
   const item = {
     history: [],
     isPublished: true,
-    isAnnualReview: false
-  }
+    isAnnualReview: false,
+  };
 
   expect(getPublishingStatus(item)).toBe("live");
 
   const itemHasBeenArchived = {
     ...item,
-    history: [{
-      type: "ARCHIVED"
-    }]
-  }
+    history: [
+      {
+        type: "ARCHIVED",
+      },
+    ],
+  };
 
-  expect(getPublishingStatus(itemHasBeenArchived)).toBe("archived")
-
-})
+  expect(getPublishingStatus(itemHasBeenArchived)).toBe("archived");
+});
 
 test("getPublishingStatus returns unpublished correctly", () => {
   const item = {
     history: [],
     isPublished: false,
-    isAnnualReview: false
-  }
+    isAnnualReview: false,
+  };
   const itemWithStatus = {
     ...item,
     status: "UNPUBLISHED",
-  }
+  };
 
-  expect(getPublishingStatus(itemWithStatus)).toBe("unpublished")
+  expect(getPublishingStatus(itemWithStatus)).toBe("unpublished");
 
   const itemUnpublishedSincePublishing = {
     ...item,
@@ -174,10 +191,10 @@ test("getPublishingStatus returns unpublished correctly", () => {
       {
         type: "PUBLISHED",
       },
-    ]
-  }
+    ],
+  };
 
-  expect(getPublishingStatus(itemUnpublishedSincePublishing)).toBe("unpublished")
+  expect(getPublishingStatus(itemUnpublishedSincePublishing)).toBe("unpublished");
 
   const publishedSinceUnpublishing = {
     ...item,
@@ -191,103 +208,88 @@ test("getPublishingStatus returns unpublished correctly", () => {
       {
         type: "PUBLISHED",
       },
-    ]
-  }
+    ],
+  };
 
-  expect(getPublishingStatus(publishedSinceUnpublishing)).toBe("live")
-
+  expect(getPublishingStatus(publishedSinceUnpublishing)).toBe("live");
 });
 
 test("hasBeenUnpublishedSincePublishing", () => {
+  expect(hasBeenUnpublishedSincePublishing([{ type: "UNPUBLISHED" }])).toBe(true);
 
-  expect(hasBeenUnpublishedSincePublishing([
-    { type: "UNPUBLISHED" },
-  ])).toBe(true)
+  expect(hasBeenUnpublishedSincePublishing([{ type: "UNPUBLISHED" }, { type: "PUBLISHED" }])).toBe(true);
 
-  expect(hasBeenUnpublishedSincePublishing([
-    { type: "UNPUBLISHED" },
-    { type: "PUBLISHED" },
-  ])).toBe(true)
+  expect(hasBeenUnpublishedSincePublishing([{ type: "PUBLISHED" }, { type: "UNPUBLISHED" }])).toBe(false);
 
-  expect(hasBeenUnpublishedSincePublishing([
-    { type: "PUBLISHED" },
-    { type: "UNPUBLISHED" },
-  ])).toBe(false)
+  expect(
+    hasBeenUnpublishedSincePublishing([
+      { type: "PUBLISHED" },
+      { type: "EDITED" },
+      { type: "OUT_WITH_PROVIDER" },
+      { type: "NEW" },
+    ])
+  ).toBe(false);
 
-  expect(hasBeenUnpublishedSincePublishing([
-    { type: "PUBLISHED" },
-    { type: "EDITED" },
-    { type: "OUT_WITH_PROVIDER" },
-    { type: "NEW" },
-  ])).toBe(false)
+  expect(
+    hasBeenUnpublishedSincePublishing([
+      { type: "UNPUBLISHED" },
+      { type: "PUBLISHED" },
+      { type: "EDITED" },
+      { type: "OUT_WITH_PROVIDER" },
+      { type: "NEW" },
+    ])
+  ).toBe(true);
 
-  expect(hasBeenUnpublishedSincePublishing([
-    { type: "UNPUBLISHED" },
-    { type: "PUBLISHED" },
-    { type: "EDITED" },
-    { type: "OUT_WITH_PROVIDER" },
-    { type: "NEW" },
-  ])).toBe(true)
+  expect(
+    hasBeenUnpublishedSincePublishing([{ type: "UNPUBLISHED" }, { type: "PUBLISHED" }, { type: "UNPUBLISHED" }])
+  ).toBe(true);
 
-
-  expect(hasBeenUnpublishedSincePublishing([
-    { type: "UNPUBLISHED" },
-    { type: "PUBLISHED" },
-    { type: "UNPUBLISHED" },
-  ])).toBe(true)
-
-  expect(hasBeenUnpublishedSincePublishing([
-    { type: "PUBLISHED" },
-    { type: "UNPUBLISHED" },
-    { type: "PUBLISHED" },
-    { type: "UNPUBLISHED" },
-  ])).toBe(false)
-
-})
+  expect(
+    hasBeenUnpublishedSincePublishing([
+      { type: "PUBLISHED" },
+      { type: "UNPUBLISHED" },
+      { type: "PUBLISHED" },
+      { type: "UNPUBLISHED" },
+    ])
+  ).toBe(false);
+});
 
 test("hasBeenPublishedSinceUnpublishing", () => {
+  expect(hasBeenPublishedSinceUnpublishing([{ type: "PUBLISHED" }])).toBe(true);
 
-  expect(hasBeenPublishedSinceUnpublishing([
-    { type: "PUBLISHED" },
-  ])).toBe(true)
+  expect(hasBeenPublishedSinceUnpublishing([{ type: "UNPUBLISHED" }, { type: "PUBLISHED" }])).toBe(false);
 
-  expect(hasBeenPublishedSinceUnpublishing([
-    { type: "UNPUBLISHED" },
-    { type: "PUBLISHED" },
-  ])).toBe(false)
+  expect(hasBeenPublishedSinceUnpublishing([{ type: "PUBLISHED" }, { type: "UNPUBLISHED" }])).toBe(true);
 
-  expect(hasBeenPublishedSinceUnpublishing([
-    { type: "PUBLISHED" },
-    { type: "UNPUBLISHED" },
-  ])).toBe(true)
+  expect(
+    hasBeenPublishedSinceUnpublishing([
+      { type: "PUBLISHED" },
+      { type: "EDITED" },
+      { type: "OUT_WITH_PROVIDER" },
+      { type: "NEW" },
+    ])
+  ).toBe(true);
 
-  expect(hasBeenPublishedSinceUnpublishing([
-    { type: "PUBLISHED" },
-    { type: "EDITED" },
-    { type: "OUT_WITH_PROVIDER" },
-    { type: "NEW" },
-  ])).toBe(true)
+  expect(
+    hasBeenPublishedSinceUnpublishing([
+      { type: "UNPUBLISHED" },
+      { type: "PUBLISHED" },
+      { type: "EDITED" },
+      { type: "OUT_WITH_PROVIDER" },
+      { type: "NEW" },
+    ])
+  ).toBe(false);
 
-  expect(hasBeenPublishedSinceUnpublishing([
-    { type: "UNPUBLISHED" },
-    { type: "PUBLISHED" },
-    { type: "EDITED" },
-    { type: "OUT_WITH_PROVIDER" },
-    { type: "NEW" },
-  ])).toBe(false)
+  expect(
+    hasBeenPublishedSinceUnpublishing([{ type: "UNPUBLISHED" }, { type: "PUBLISHED" }, { type: "UNPUBLISHED" }])
+  ).toBe(false);
 
-
-  expect(hasBeenPublishedSinceUnpublishing([
-    { type: "UNPUBLISHED" },
-    { type: "PUBLISHED" },
-    { type: "UNPUBLISHED" },
-  ])).toBe(false)
-
-  expect(hasBeenPublishedSinceUnpublishing([
-    { type: "PUBLISHED" },
-    { type: "UNPUBLISHED" },
-    { type: "PUBLISHED" },
-    { type: "UNPUBLISHED" },
-  ])).toBe(true)
-})
-
+  expect(
+    hasBeenPublishedSinceUnpublishing([
+      { type: "PUBLISHED" },
+      { type: "UNPUBLISHED" },
+      { type: "PUBLISHED" },
+      { type: "UNPUBLISHED" },
+    ])
+  ).toBe(true);
+});

--- a/src/server/models/listItem/listItem.ts
+++ b/src/server/models/listItem/listItem.ts
@@ -1,19 +1,7 @@
 import { WebhookData } from "server/components/formRunner";
-import {
-  List,
-  Point,
-  ServiceType,
-  User,
-  ListItem,
-} from "server/models/types";
-import {
-  ListItemWithAddressCountry,
-  ListItemWithJsonData,
-} from "server/models/listItem/providers/types";
-import {
-  makeAddressGeoLocationString,
-  getCountryFromData,
-} from "server/models/listItem/geoHelpers";
+import { List, Point, ServiceType, User, ListItem } from "server/models/types";
+import { ListItemWithAddressCountry, ListItemWithJsonData } from "server/models/listItem/providers/types";
+import { makeAddressGeoLocationString, getCountryFromData } from "server/models/listItem/geoHelpers";
 import { rawUpdateGeoLocation } from "server/models/helpers";
 import { geoLocatePlaceByText } from "server/services/location";
 import { recordListItemEvent } from "server/models/audit";
@@ -22,13 +10,7 @@ import { listItemCreateInputFromWebhook } from "./listItemCreateInputFromWebhook
 import pgescape from "pg-escape";
 import { prisma } from "../db/prisma-client";
 import { logger } from "server/services/logger";
-import {
-  AuditEvent,
-  ListItemEvent,
-  Prisma,
-  Status,
-  ListItem as PrismaListItem,
-} from "@prisma/client";
+import { AuditEvent, ListItemEvent, Prisma, Status, ListItem as PrismaListItem } from "@prisma/client";
 import { merge } from "lodash";
 import { DeserialisedWebhookData } from "./providers/deserialisers/types";
 import { EVENTS } from "./listItemEvent";
@@ -107,19 +89,17 @@ export async function findListItemById(id: string | number) {
         },
         history: {
           orderBy: {
-            time: 'desc'
-          }
+            time: "desc",
+          },
         },
         pinnedBy: true,
       },
     });
-
   } catch (error) {
     logger.error(`findListItemById Error ${error.message}`);
     throw new Error(`failed to find ${id}`);
   }
 }
-
 
 /**
  * deceptive method... toggle[r]ListItemIsPublished assumedly should toggle (i.e. invert the current isPublished status).
@@ -140,9 +120,7 @@ export async function togglerListItemIsPublished({
   const event = EVENTS[status](userId);
   logger.info(`user ${userId} is setting ${id} isPublished to ${isPublished}`);
 
-  const auditEvent = isPublished
-    ? AuditEvent.PUBLISHED
-    : AuditEvent.UNPUBLISHED;
+  const auditEvent = isPublished ? AuditEvent.PUBLISHED : AuditEvent.UNPUBLISHED;
 
   try {
     const [listItem] = await prisma.$transaction([
@@ -153,8 +131,8 @@ export async function togglerListItemIsPublished({
           isPublished,
           status,
           history: {
-            create: [event]
-          }
+            create: [event],
+          },
         },
         include: {
           address: {
@@ -182,16 +160,11 @@ export async function togglerListItemIsPublished({
   }
 }
 
-
 interface SetEmailIsVerified {
   type?: ServiceType;
 }
 
-export async function setEmailIsVerified({
-  reference,
-}: {
-  reference: string;
-}): Promise<SetEmailIsVerified> {
+export async function setEmailIsVerified({ reference }: { reference: string }): Promise<SetEmailIsVerified> {
   try {
     const item = await prisma.listItem.findUnique({
       where: { reference },
@@ -216,7 +189,7 @@ export async function setEmailIsVerified({
     const updatedJsonData = {
       ...jsonData,
       metadata: { ...metadata, emailVerified: true },
-    }
+    };
 
     await prisma.listItem.update({
       where: { reference },
@@ -232,9 +205,7 @@ export async function setEmailIsVerified({
   }
 }
 
-export async function createListItem(
-  webhookData: WebhookData
-): Promise<ListItemWithAddressCountry> {
+export async function createListItem(webhookData: WebhookData): Promise<ListItemWithAddressCountry> {
   try {
     const data = await listItemCreateInputFromWebhook(webhookData);
 
@@ -264,11 +235,11 @@ export async function createListItem(
 
 type Nullable<T> = T | undefined | null;
 
-export async function update(
-  id: ListItem["id"],
-  userId: User["id"],
-  data: DeserialisedWebhookData
-): Promise<void> {
+/**
+ * updates and PUBLISHES.
+ */
+export async function update(id: ListItem["id"], userId: User["id"], data: DeserialisedWebhookData): Promise<void> {
+  logger.info(`${userId} is attempting to update ${id} with ${data}`);
   const listItemResult = await prisma.listItem
     .findFirst({
       where: { id },
@@ -307,7 +278,7 @@ export async function update(
       itemId: id,
       userId,
     },
-  }
+  };
 
   let geoLocationParams: Nullable<[number, Point]>;
 
@@ -323,7 +294,6 @@ export async function update(
     }
   }
 
-
   const listItemPrismaQuery: Prisma.ListItemUpdateArgs = {
     where: { id },
     data: {
@@ -332,15 +302,15 @@ export async function update(
       isPublished: true,
       status: Status.PUBLISHED,
       history: {
-        create: [ updateEvent ]
+        create: [updateEvent],
       },
       ...(requiresAddressUpdate && {
         address: {
           update: {
-            ...addressUpdates
-          }
-        }
-      })
+            ...addressUpdates,
+          },
+        },
+      }),
     },
   };
 
@@ -357,29 +327,24 @@ export async function update(
         updatedJsonData,
       },
       AuditEvent.PUBLISHED
-    )
+    );
 
-    if(requiresAddressUpdate) {
-      result = await prisma.$transaction([updateItem, rawUpdateGeoLocation(...geoLocationParams!), updateAudit])
+    if (requiresAddressUpdate) {
+      result = await prisma.$transaction([updateItem, rawUpdateGeoLocation(...geoLocationParams!), updateAudit]);
     } else {
-      result = await prisma.$transaction([updateItem, updateAudit])
+      result = await prisma.$transaction([updateItem, updateAudit]);
     }
 
     if (!result) {
       throw Error("listItem.update prisma update failed");
     }
   } catch (err) {
-    logger.error(
-      `listItem.update transactional error - rolling back ${err.message}`
-    );
+    logger.error(`listItem.update transactional error - rolling back ${err.message}`);
     throw err;
   }
 }
 
-export async function deleteListItem(
-  id: number,
-  userId: User["id"]
-): Promise<void> {
+export async function deleteListItem(id: number, userId: User["id"]): Promise<void> {
   if (userId === undefined) {
     throw new Error("deleteListItem Error: userId is undefined");
   }

--- a/src/server/models/listItem/listItem.ts
+++ b/src/server/models/listItem/listItem.ts
@@ -10,7 +10,7 @@ import { listItemCreateInputFromWebhook } from "./listItemCreateInputFromWebhook
 import pgescape from "pg-escape";
 import { prisma } from "../db/prisma-client";
 import { logger } from "server/services/logger";
-import { AuditEvent, ListItemEvent, Prisma, Status, ListItem as PrismaListItem } from "@prisma/client";
+import { AuditEvent, Prisma, Status, ListItem as PrismaListItem } from "@prisma/client";
 import { merge } from "lodash";
 import { DeserialisedWebhookData } from "./providers/deserialisers/types";
 import { EVENTS } from "./listItemEvent";
@@ -246,7 +246,7 @@ export async function update(
   logger.info(`user ${userId} is attempting to update ${id}`);
   if (legacyDataParameter) {
     logger.info(
-      `legacy data parameter used. updating with ${legacyDataParameter} however ListItem.jsonData.updatedJsonData should be used`
+      "legacy data parameter used. updating with legacy data parameter however ListItem.jsonData.updatedJsonData should be used"
     );
   }
   const listItemResult = await prisma.listItem

--- a/src/server/models/listItem/listItem.ts
+++ b/src/server/models/listItem/listItem.ts
@@ -244,7 +244,7 @@ export async function update(
   legacyDataParameter?: DeserialisedWebhookData
 ): Promise<void> {
   logger.info(`user ${userId} is attempting to update ${id}`);
-  if (data) {
+  if (legacyDataParameter) {
     logger.info(
       `legacy data parameter used. updating with ${legacyDataParameter} however ListItem.jsonData.updatedJsonData should be used`
     );

--- a/src/server/models/listItem/listItem.ts
+++ b/src/server/models/listItem/listItem.ts
@@ -270,16 +270,6 @@ export async function update(id: ListItem["id"], userId: User["id"], data: Deser
     updatedJsonData.localServicesProvided = localServicesProvided;
   }
 
-  const updateEvent = {
-    time: new Date(),
-    type: ListItemEvent.PUBLISHED,
-    jsonData: {
-      eventName: "publish",
-      itemId: id,
-      userId,
-    },
-  };
-
   let geoLocationParams: Nullable<[number, Point]>;
 
   if (requiresAddressUpdate) {
@@ -302,7 +292,7 @@ export async function update(id: ListItem["id"], userId: User["id"], data: Deser
       isPublished: true,
       status: Status.PUBLISHED,
       history: {
-        create: [updateEvent],
+        create: EVENTS.PUBLISHED(userId),
       },
       ...(requiresAddressUpdate && {
         address: {

--- a/src/server/models/listItem/listItemEvent.ts
+++ b/src/server/models/listItem/listItemEvent.ts
@@ -77,7 +77,7 @@ export const EVENTS = {
     type: ListItemEvent.EDITED,
     jsonData: {
       eventName: "edited",
-      ...updatedJsonData,
+      updatedJsonData,
     },
   }),
 

--- a/src/server/models/listItem/listItemEvent.ts
+++ b/src/server/models/listItem/listItemEvent.ts
@@ -50,8 +50,9 @@ export const EVENTS = {
     };
   },
 
-  [ListItemEvent.DELETED]: (userId: number): EventCreate<"DELETED"> => ({
+  [ListItemEvent.DELETED]: (userId: number, id?: number): EventCreate<"DELETED"> => ({
     type: ListItemEvent.DELETED,
+    ...(id && { listItemId: id }),
     jsonData: {
       eventName: "deleted",
       userId,
@@ -76,6 +77,7 @@ export const EVENTS = {
   [ListItemEvent.EDITED]: (updatedJsonData = {}): EventCreate<"EDITED"> => ({
     type: ListItemEvent.EDITED,
     jsonData: {
+      notes: ["user resubmitted with this data"],
       eventName: "edited",
       updatedJsonData,
     },

--- a/src/server/models/listItem/summary.helpers.ts
+++ b/src/server/models/listItem/summary.helpers.ts
@@ -117,16 +117,15 @@ export function getActivityStatus(item: ListItemWithHistory): ActivityStatusView
   }
 
   if (!isPublished) {
+    if (status === "OUT_WITH_PROVIDER") {
+      return statusToActivityVM.OUT_WITH_PROVIDER;
+    }
     if (wasUnpublishedByUser(history)) {
       return statusToActivityVM.UNPUBLISHED;
     }
     if (status === "ANNUAL_REVIEW_OVERDUE") {
       return statusToActivityVM.ANNUAL_REVIEW_OVERDUE;
     }
-  }
-
-  if (status === "PUBLISHED" && !item.isAnnualReview) {
-    return statusToActivityVM.PUBLISHED;
   }
 
   return statusToActivityVM[status];

--- a/src/server/models/listItem/summary.helpers.ts
+++ b/src/server/models/listItem/summary.helpers.ts
@@ -1,51 +1,48 @@
-import {Event, ListItem, ListItemEvent, Prisma, Status} from "@prisma/client";
-import {ActivityStatusViewModel} from "server/models/listItem/types";
-
+import { Event, ListItem, ListItemEvent, Prisma, Status } from "@prisma/client";
+import { ActivityStatusViewModel } from "server/models/listItem/types";
 
 export const statusToActivityVM: Record<Status, ActivityStatusViewModel> = {
   NEW: {
-    type: 'to_do',
-    text: 'Check new entry'
+    type: "to_do",
+    text: "Check new entry",
   },
   OUT_WITH_PROVIDER: {
-    type: 'out_with_provider',
-    text: 'Edits requested'
+    type: "out_with_provider",
+    text: "Edits requested",
   },
   EDITED: {
-    text: 'Check edits',
-    type: 'to_do'
+    text: "Check edits",
+    type: "to_do",
   },
   CHECK_ANNUAL_REVIEW: {
-    text: 'Check annual review',
-    type: 'to_do'
+    text: "Check annual review",
+    type: "to_do",
   },
   ANNUAL_REVIEW_OVERDUE: {
-    text: 'Annual review overdue',
-    type: 'out_with_provider'
+    text: "Annual review overdue",
+    type: "out_with_provider",
   },
   PUBLISHED: {
-    text: 'No action needed',
-    type: 'no_action_needed'
+    text: "No action needed",
+    type: "no_action_needed",
   },
   UNPUBLISHED: {
-    text: 'Removed by post',
-    type: 'to_do',
-    colour: 'red',
+    text: "Removed by post",
+    type: "to_do",
+    colour: "red",
   },
-}
-
+};
 
 export enum PUBLISHING_STATUS {
   new = "new",
   live = "live",
   unpublished = "unpublished",
-  archived = "archived"
+  archived = "archived",
 }
-
 
 export type ListItemWithHistory = ListItem & {
-  history: Event[]
-}
+  history: Event[];
+};
 
 /**
  * The prisma query must be called with
@@ -57,7 +54,7 @@ export type ListItemWithHistory = ListItem & {
  * These functions do not do any additional sorting.
  */
 export function newestEventOfTypeIndex(history: Event[], type: ListItemEvent): number {
-  return history.findIndex(event => event.type === type)
+  return history.findIndex((event) => event.type === type);
 }
 
 export function hasBeenUnpublishedSincePublishing(history: Event[]): boolean {
@@ -66,11 +63,11 @@ export function hasBeenUnpublishedSincePublishing(history: Event[]): boolean {
   const hasUnpublishEvent = newestUnpublishEvent !== -1;
   const hasPublishEvent = newestPublishEvent !== -1;
 
-  if(!hasPublishEvent && hasUnpublishEvent) {
-    return true
+  if (!hasPublishEvent && hasUnpublishEvent) {
+    return true;
   }
 
-  return  hasUnpublishEvent && newestUnpublishEvent < newestPublishEvent;
+  return hasUnpublishEvent && newestUnpublishEvent < newestPublishEvent;
 }
 
 export function hasBeenPublishedSinceUnpublishing(history: Event[]): boolean {
@@ -79,56 +76,58 @@ export function hasBeenPublishedSinceUnpublishing(history: Event[]): boolean {
   const hasUnpublishEvent = newestUnpublishEvent !== -1;
   const hasPublishEvent = newestPublishEvent !== -1;
 
-  if(!hasUnpublishEvent && hasPublishEvent) {
-    return true
+  if (!hasUnpublishEvent && hasPublishEvent) {
+    return true;
   }
   return hasPublishEvent && newestPublishEvent < newestUnpublishEvent;
 }
 
-
 export function hasBeenArchived(history: Event[]) {
-  return history.find(event => event.type === "ARCHIVED")
+  return history.find((event) => event.type === "ARCHIVED");
 }
 
 export function getPublishingStatus(item: ListItemWithHistory): PUBLISHING_STATUS {
-  if(hasBeenArchived(item.history)) {
+  if (hasBeenArchived(item.history)) {
     return PUBLISHING_STATUS.archived;
   }
 
-  if(item.isPublished || hasBeenPublishedSinceUnpublishing(item.history)) {
-    return PUBLISHING_STATUS.live
+  if (item.isPublished || hasBeenPublishedSinceUnpublishing(item.history)) {
+    return PUBLISHING_STATUS.live;
   }
 
-  if(hasBeenUnpublishedSincePublishing(item.history) || item.status === "UNPUBLISHED") {
-    return PUBLISHING_STATUS.unpublished
+  if (hasBeenUnpublishedSincePublishing(item.history) || item.status === "UNPUBLISHED") {
+    return PUBLISHING_STATUS.unpublished;
   }
 
-  return PUBLISHING_STATUS.new
+  return PUBLISHING_STATUS.new;
 }
 
 export function wasUnpublishedByUser(history: Event[]): boolean {
-  const event = history.find(event => event.type === 'UNPUBLISHED')
+  const event = history.find((event) => event.type === "UNPUBLISHED");
   const jsonData = event?.jsonData as Prisma.JsonObject;
   const userId = jsonData?.userId ?? false;
-  return userId !== false
+  return userId !== false;
 }
 
 export function getActivityStatus(item: ListItemWithHistory): ActivityStatusViewModel {
   const { history, status, isPublished } = item;
 
-  if(!isPublished) {
-    if(wasUnpublishedByUser(history)) {
-      return statusToActivityVM.UNPUBLISHED
+  if (status === "EDITED") {
+    return statusToActivityVM.EDITED;
+  }
+
+  if (!isPublished) {
+    if (wasUnpublishedByUser(history)) {
+      return statusToActivityVM.UNPUBLISHED;
     }
-    if(status === "ANNUAL_REVIEW_OVERDUE") {
-      return statusToActivityVM.ANNUAL_REVIEW_OVERDUE
+    if (status === "ANNUAL_REVIEW_OVERDUE") {
+      return statusToActivityVM.ANNUAL_REVIEW_OVERDUE;
     }
   }
 
-  if(status === 'PUBLISHED' && !item.isAnnualReview) {
-    return statusToActivityVM.PUBLISHED
+  if (status === "PUBLISHED" && !item.isAnnualReview) {
+    return statusToActivityVM.PUBLISHED;
   }
 
-  return statusToActivityVM[status]
-
+  return statusToActivityVM[status];
 }

--- a/src/server/models/listItem/summary.ts
+++ b/src/server/models/listItem/summary.ts
@@ -39,7 +39,11 @@ async function findPinnedIndexListItems(options: ListIndexOptions) {
     select: {
       pinnedItems: {
         include: {
-          history: true,
+          history: {
+            orderBy: {
+              time: "desc",
+            },
+          },
         },
         where: {
           listId: options.listId,

--- a/src/server/services/location.ts
+++ b/src/server/services/location.ts
@@ -27,16 +27,13 @@ export function getAWSLocationService(): Location {
   return location;
 }
 
-export async function checkIfPlaceIndexExists(
-  placeIndexName: string
-): Promise<boolean> {
+export async function checkIfPlaceIndexExists(placeIndexName: string): Promise<boolean> {
   try {
     const location = getAWSLocationService();
     const result = await location.listPlaceIndexes().promise();
     return result?.Entries?.some((entry) => entry.IndexName === placeIndexName);
   } catch (error) {
-    const typedError = error as Error;
-    logger.error(`checkIfPlaceIndexExists Error: ${typedError.message}`);
+    logger.error(`checkIfPlaceIndexExists Error: ${error.message}`);
     return false;
   }
 }
@@ -59,21 +56,15 @@ export async function createPlaceIndex(): Promise<boolean> {
   }
 }
 
-export async function geoLocatePlaceByText(
-  region: string,
-  country: string
-): Promise<Location.Types.Position> {
+export async function geoLocatePlaceByText(region: string, country: string): Promise<Location.Types.Position> {
   if (!placeIndexExists) {
     placeIndexExists = await createPlaceIndex();
   }
 
   const location = getAWSLocationService();
-  const countryCode = region.toLowerCase().includes("vatican")
-    ? "VAT"
-    : getCountryCodeFromCountryName(country);
+  const countryCode = region.toLowerCase().includes("vatican") ? "VAT" : getCountryCodeFromCountryName(country);
 
-  if (!countryCode)
-    throw new Error(`A country code for ${country} could not be found.`);
+  if (!countryCode) throw new Error(`A country code for ${country} could not be found.`);
 
   const { Results } = await location
     .searchPlaceIndexForText({


### PR DESCRIPTION
- ensuring `check edits` has a higher "priority" than `removed by post`
  - https://trello.com/c/8osLTPDj/1518-annual-review-testing-making-something-a-favourite-changes-its-publishing-status
- resolve issue with publishing. updatedJsonData was being destructured but should've been `{ updatedJsonData }`. 
  - https://trello.com/c/XKjb8THz/1519-annual-review-testing-sending-things-for-review-or-publishing-doesnt-always-change-the-status




