### PR TITLE
chore: remove duplicate page for sworn journey

### DIFF
--- a/docker/apply/forms-json/translators-interpreters.json
+++ b/docker/apply/forms-json/translators-interpreters.json
@@ -284,9 +284,8 @@
         }
       ],
       "next": [
-        {
-          "path": "/have-you-provided-services-to-british-nationals-before"
-        }
+        { "path": "/are-you-a-sworn-interpreter-in-your-country" },
+        { "path": "/have-you-provided-services-to-british-nationals-before", "condition": "tkpRoc" }
       ]
     },
     {
@@ -639,26 +638,8 @@
       ],
       "next": [
         {
-          "path": "/are-you-a-sworn-translator-and-interpreter-in-your-country"
+          "path": "/are-you-a-sworn-translator-in-your-country"
         }
-      ]
-    },
-    {
-      "path": "/are-you-a-sworn-translator-and-interpreter-in-your-country",
-      "title": "Are you a certified or sworn translator in your country?",
-      "components": [
-        {
-          "name": "swornTranslationsForInterpreters",
-          "options": {},
-          "type": "YesNoField",
-          "hint": "If sworn or certified translation is not used in your country, select 'No'.",
-          "title": "Are you a certified or sworn translator in your country?",
-          "schema": {}
-        }
-      ],
-      "next": [
-        { "path": " /are-you-a-sworn-interpreter-in-your-country" },
-        { "path": "/are-you-a-sworn-interpreter-in-your-country" }
       ]
     },
     {


### PR DESCRIPTION
# Description

The purpose of this PR is the remove the duplicate page for translating in the sworn journey for interpreters. This should make the data in the DB a bit cleaner.