### PR TITLE
fix: correctly render sworn data for dashboard 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
+    branches: ['master', '[0-9].*.*']
 
 jobs:
   release:

--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
   },
   "release": {
     "branches": [
-      "master"
+      "master",
+      "+([0-9])?(.{+([0-9]),x}).x"
     ]
   }
 }

--- a/src/server/components/dashboard/listsItems/getViewModel.ts
+++ b/src/server/components/dashboard/listsItems/getViewModel.ts
@@ -15,7 +15,7 @@ interface DetailsViewModel {
 /**
  * TODO: implement i18n
  */
-export const fieldTitles: { [prop: string]: string } = {
+const fieldTitles: { [prop: string]: string } = {
   /**
    * used to convert fieldNames to a user-facing string
    */

--- a/src/server/components/dashboard/listsItems/getViewModel.ts
+++ b/src/server/components/dashboard/listsItems/getViewModel.ts
@@ -47,8 +47,8 @@ export const fieldTitles: { [prop: string]: string } = {
   translationSpecialties: "Translation services",
   interpreterServices: "Interpretation services",
   deliveryOfServices: "How services are carried out",
-  swornTranslations: "Provides sworn interpretation",
-  swornInterpretations: "Provides sworn or certified translation",
+  swornTranslations: "Provides sworn or certified translation",
+  swornInterpretations: "Provides sworn interpretation",
 };
 
 type KeyOfJsonData = keyof ListItemJsonData;

--- a/src/server/components/dashboard/listsItems/getViewModel.ts
+++ b/src/server/components/dashboard/listsItems/getViewModel.ts
@@ -222,13 +222,8 @@ function formatRowsForTranslators(
     jsonData.languagesProvided = languagesArray;
   }
 
-  if (jsonData.updatedJsonData?.swornInterpretations) {
-    jsonData.swornInterpretations = jsonData.swornInterpretations ?? jsonData.updatedJsonData.swornInterpretations;
-  }
-
-  if (jsonData.updatedJsonData?.swornTranslations) {
-    jsonData.swornTranslations = jsonData.swornTranslations ?? jsonData.updatedJsonData.swornTranslations;
-  }
+  jsonData.swornInterpretations ??= jsonData.updatedJsonData?.swornInterpretations;
+  jsonData.swornTranslations ??= jsonData.updatedJsonData?.swornTranslations;
 
   return jsonDataAsRows(fields, jsonData);
 }

--- a/src/server/components/dashboard/listsItems/getViewModel.ts
+++ b/src/server/components/dashboard/listsItems/getViewModel.ts
@@ -188,14 +188,14 @@ function getOrganisationRows(listItem: ListItemGetObject): Types.govukRow[] {
     [ServiceType.translatorsInterpreters]: [
       ...baseFields,
       "servicesProvided",
+      "swornTranslations",
+      "swornInterpretations",
       "languagesProvided",
       "languagesSummary",
       "translationSpecialties",
       "interpreterServices",
       "deliveryOfServices",
       "representedBritishNationals",
-      "swornTranslations",
-      "swornInterpretations",
     ],
   };
 

--- a/src/server/components/dashboard/listsItems/helpers.ts
+++ b/src/server/components/dashboard/listsItems/helpers.ts
@@ -78,10 +78,17 @@ export function mapUpdatedAuditJsonDataToListItem(
   listItem: ListItemGetObject,
   updatedJsonData: ListItemJsonData
 ): ListItemJsonData {
+  /**
+   * Cherry-picked from origin/feat/1541-sworn-list-fix
+   */
+  const swornTranslatorFields =
+    listItem.type === "translatorsInterpreters" ? ["swornInterpretations", "swornTranslations"] : [];
   return Object.assign(
     {},
     listItem.jsonData,
-    ...Object.keys(listItem.jsonData).map((k) => k in updatedJsonData && { [k]: updatedJsonData[k] })
+    ...[...Object.keys(listItem.jsonData), ...swornTranslatorFields].map(
+      (k) => k in updatedJsonData && { [k]: updatedJsonData[k] }
+    )
   );
 }
 


### PR DESCRIPTION
see #528 

Currently, the answers for "Are you a certified or sworn translator" and "Are you a sworn interpreter" are not being displayed in the dashboard for post (even though the user has been asked to update their details and have now answered the question), if the applicant applied before the new question was introduced. 

**changes made**
- add swornTranslation and swornInterpretation to ViewModel
- if `listItem.jsonData.swornTranslation` or `listItem.jsonData.swornTranslation` is null (i.e. user answered before v1.46.1), display the updated value from `listItem.jsonData.updatedJsonData.swornTranslation`)
