### PR TITLE
fix: use history based filter instead of statuses

### DIFF
--- a/src/server/models/listItem/queryFactory.ts
+++ b/src/server/models/listItem/queryFactory.ts
@@ -45,9 +45,14 @@ export const queryToPrismaQueryMap: Record<keyof Tags, Prisma.ListItemWhereInput
   unpublished: {
     AND: [
       {
-        status: {
-          in: ["UNPUBLISHED", "ANNUAL_REVIEW_OVERDUE"],
+        history: {
+          some: {
+            type: "PUBLISHED",
+          },
         },
+      },
+      {
+        isPublished: false,
       },
       {
         NOT: {


### PR DESCRIPTION
If you filter by Unpublished (on its own) it only shows the ones that are in this state

![image](https://user-images.githubusercontent.com/22080510/212715247-a796e5c3-bc00-44d5-b0b0-df86fbabce0b.png)

![image](https://user-images.githubusercontent.com/22080510/212715274-2965c7f6-8cfe-494c-9b60-8213b8431dd5.png)

**changes made**
- use a history based search, to check for an `PUBLISHED` event, then check for `isPublished = false`