### PR TITLE
Refactored unpublish key dates

### DIFF
--- a/src/scheduler/batch/__tests__/helpers.test.ts
+++ b/src/scheduler/batch/__tests__/helpers.test.ts
@@ -62,14 +62,14 @@ describe("Date Contexts", () => {
       },
       {
         eventDate: new Date(2023, 1, 6, 0, 0, 0),
-        eventMilestone: schedulerMilestoneDays.provider.ONE_WEEK,
+        eventMilestone: schedulerMilestoneDays.both.ONE_WEEK,
       },
       {
         eventDate: new Date(2023, 1, 12, 0, 0, 0),
-        eventMilestone: schedulerMilestoneDays.provider.ONE_DAY,
+        eventMilestone: schedulerMilestoneDays.both.ONE_DAY,
       },
       {
-        eventDate: new Date(2023, 0, 16, 0, 0, 0),
+        eventDate: new Date(2023, 1, 13, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.both.UNPUBLISH,
       },
     ];

--- a/src/scheduler/batch/__tests__/helpers.test.ts
+++ b/src/scheduler/batch/__tests__/helpers.test.ts
@@ -69,7 +69,7 @@ describe("Date Contexts", () => {
         eventMilestone: schedulerMilestoneDays.provider.ONE_DAY,
       },
       {
-        eventDate: new Date(2023, 1, 13, 0, 0, 0),
+        eventDate: new Date(2023, 0, 16, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.both.UNPUBLISH,
       },
     ];
@@ -81,8 +81,8 @@ describe("Date Contexts", () => {
       schedulerMilestoneDays.provider.FOUR_WEEKS,
       schedulerMilestoneDays.provider.THREE_WEEKS,
       schedulerMilestoneDays.provider.TWO_WEEKS,
-      schedulerMilestoneDays.provider.ONE_WEEK,
-      schedulerMilestoneDays.provider.ONE_DAY,
+      schedulerMilestoneDays.both.ONE_WEEK,
+      schedulerMilestoneDays.both.ONE_DAY,
       schedulerMilestoneDays.both.START,
     ])("provider milestone contexts", (milestoneDays) => {
       const { expectedContext, actualContext } = testContext(

--- a/src/scheduler/batch/__tests__/main.test.ts
+++ b/src/scheduler/batch/__tests__/main.test.ts
@@ -41,11 +41,11 @@ const unpublish: DateContext[] = [
   },
   {
     eventDate: new Date(2023, 1, 6, 0, 0, 0),
-    eventMilestone: schedulerMilestoneDays.provider.ONE_WEEK,
+    eventMilestone: schedulerMilestoneDays.both.ONE_WEEK,
   },
   {
     eventDate: new Date(2023, 1, 12, 0, 0, 0),
-    eventMilestone: schedulerMilestoneDays.provider.ONE_DAY,
+    eventMilestone: schedulerMilestoneDays.both.ONE_DAY,
   },
   {
     eventDate: new Date(2023, 1, 13, 0, 0, 0),

--- a/src/scheduler/batch/__tests__/main.test.ts
+++ b/src/scheduler/batch/__tests__/main.test.ts
@@ -1,8 +1,5 @@
 import { DateContext, getDateContexts, schedulerMilestoneDays, SchedulerDateContexts } from "../helpers";
-import * as listItem from "../../../server/models/listItem";
-import { List, ListItem, ListItemGetObject } from "../../../server/models/types";
-import { populateCurrentAnnualReview } from "../main";
-import { logger } from "server/services/logger";
+import { List, ListItem } from "../../../server/models/types";
 
 jest.mock("server/services/logger");
 
@@ -87,8 +84,8 @@ describe("Date Contexts", () => {
       schedulerMilestoneDays.provider.FOUR_WEEKS,
       schedulerMilestoneDays.provider.THREE_WEEKS,
       schedulerMilestoneDays.provider.TWO_WEEKS,
-      schedulerMilestoneDays.provider.ONE_WEEK,
-      schedulerMilestoneDays.provider.ONE_DAY,
+      schedulerMilestoneDays.both.ONE_WEEK,
+      schedulerMilestoneDays.both.ONE_DAY,
       schedulerMilestoneDays.both.START,
     ])("unpublished date context for milestone days", (milestoneDays) => {
       const { expectedContext, actualContext } = testContext(actualUnpublishContext, unpublish, milestoneDays);

--- a/src/scheduler/batch/helpers.ts
+++ b/src/scheduler/batch/helpers.ts
@@ -18,6 +18,8 @@ export const schedulerMilestoneDays = {
     ONE_DAY: 1,
   },
   both: {
+    ONE_WEEK: 7,
+    ONE_DAY: 1,
     START: 0,
     UNPUBLISH: 0,
   },
@@ -30,8 +32,8 @@ export type SchedulerMilestone =
   | typeof schedulerMilestoneDays.provider.FOUR_WEEKS
   | typeof schedulerMilestoneDays.provider.THREE_WEEKS
   | typeof schedulerMilestoneDays.provider.TWO_WEEKS
-  | typeof schedulerMilestoneDays.provider.ONE_WEEK
-  | typeof schedulerMilestoneDays.provider.ONE_DAY
+  | typeof schedulerMilestoneDays.both.ONE_WEEK
+  | typeof schedulerMilestoneDays.both.ONE_DAY
   | typeof schedulerMilestoneDays.both.UNPUBLISH;
 
 export interface DateContext {
@@ -58,7 +60,7 @@ function getUnpublishedDateContexts(today: Date): DateContext[] {
 
   const unpublishedDateContextsForFiltering: DateContext[] = [
     {
-      eventMilestone: schedulerMilestoneDays.provider.ONE_DAY,
+      eventMilestone: schedulerMilestoneDays.both.ONE_DAY,
       eventDate: unpublishedDateOneDayAway,
     },
     {
@@ -69,7 +71,7 @@ function getUnpublishedDateContexts(today: Date): DateContext[] {
 
   // fill in the dates between 1 to 5 weeks from the todayDateString
   for (
-    let daysBeforeEvent = schedulerMilestoneDays.provider.ONE_WEEK;
+    let daysBeforeEvent = schedulerMilestoneDays.both.ONE_WEEK;
     daysBeforeEvent <= schedulerMilestoneDays.provider.FIVE_WEEKS;
     daysBeforeEvent += 7
   ) {
@@ -166,15 +168,15 @@ export function getCurrentAnnualReviewData(
           "unpublish",
           schedulerMilestoneDays.provider.TWO_WEEKS
         ).eventDate.toISOString(),
-        PROVIDER_ONE_WEEK: getDateForContext(
+        ONE_WEEK: getDateForContext(
           contexts,
           "unpublish",
-          schedulerMilestoneDays.provider.ONE_WEEK
+          schedulerMilestoneDays.both.ONE_WEEK
         ).eventDate.toISOString(),
-        ONE_DAY_UNTIL_UNPUBLISH: getDateForContext(
+        ONE_DAY: getDateForContext(
           contexts,
           "unpublish",
-          schedulerMilestoneDays.provider.ONE_DAY
+          schedulerMilestoneDays.both.ONE_DAY
         ).eventDate.toISOString(),
         UNPUBLISH: getDateForContext(
           contexts,

--- a/src/server/components/dashboard/annualReview/helpers.keyDates.ts
+++ b/src/server/components/dashboard/annualReview/helpers.keyDates.ts
@@ -26,13 +26,13 @@ export function createKeyDatesFromISODate(isoDate: string | Date): ScheduledProc
       START: subDaysFromISODate(isoDate, 0),
     },
     unpublished: {
-      UNPUBLISH: addDaysFromISODate(isoDate, INTERVALS_IN_DAYS.provider.SIX_WEEKS),
-      ONE_DAY_UNTIL_UNPUBLISH: addDaysFromISODate(isoDate, INTERVALS_IN_DAYS.provider.SIX_WEEKS - 1),
       PROVIDER_FIVE_WEEKS: addDaysFromISODate(isoDate, INTERVALS_IN_DAYS.provider.ONE_WEEK),
       PROVIDER_FOUR_WEEKS: addDaysFromISODate(isoDate, INTERVALS_IN_DAYS.provider.TWO_WEEKS),
       PROVIDER_THREE_WEEKS: addDaysFromISODate(isoDate, INTERVALS_IN_DAYS.provider.THREE_WEEKS),
       PROVIDER_TWO_WEEKS: addDaysFromISODate(isoDate, INTERVALS_IN_DAYS.provider.FOUR_WEEKS),
-      PROVIDER_ONE_WEEK: addDaysFromISODate(isoDate, INTERVALS_IN_DAYS.provider.FIVE_WEEKS),
+      ONE_WEEK: addDaysFromISODate(isoDate, INTERVALS_IN_DAYS.provider.FIVE_WEEKS),
+      ONE_DAY: addDaysFromISODate(isoDate, INTERVALS_IN_DAYS.provider.SIX_WEEKS - 1),
+      UNPUBLISH: addDaysFromISODate(isoDate, INTERVALS_IN_DAYS.provider.SIX_WEEKS),
     },
   };
 }

--- a/src/server/components/dashboard/listsItems/controllers.development.ts
+++ b/src/server/components/dashboard/listsItems/controllers.development.ts
@@ -54,12 +54,12 @@ function parseKeyDatesFromBodyRequest(keyDates: ScheduledProcessKeyDates) {
       START: formatISOString(annualReview.START),
     },
     unpublished: {
-      ONE_DAY_UNTIL_UNPUBLISH: formatISOString(unpublished.ONE_DAY_UNTIL_UNPUBLISH),
       PROVIDER_FIVE_WEEKS: formatISOString(unpublished.PROVIDER_FIVE_WEEKS),
       PROVIDER_FOUR_WEEKS: formatISOString(unpublished.PROVIDER_FOUR_WEEKS),
       PROVIDER_THREE_WEEKS: formatISOString(unpublished.PROVIDER_THREE_WEEKS),
       PROVIDER_TWO_WEEKS: formatISOString(unpublished.PROVIDER_TWO_WEEKS),
-      PROVIDER_ONE_WEEK: formatISOString(unpublished.PROVIDER_ONE_WEEK),
+      ONE_WEEK: formatISOString(unpublished.ONE_WEEK),
+      ONE_DAY: formatISOString(unpublished.ONE_DAY),
       UNPUBLISH: formatISOString(unpublished.UNPUBLISH),
     },
   };
@@ -71,12 +71,12 @@ function flattenKeyDatesObject(keyDates: ScheduledProcessKeyDates) {
     "annualReview[POST_ONE_WEEK]": keyDates.annualReview.POST_ONE_WEEK,
     "annualReview[POST_ONE_DAY]": keyDates.annualReview.POST_ONE_DAY,
     "annualReview[START]": keyDates.annualReview.START,
-    "unpublished[ONE_DAY_UNTIL_UNPUBLISH]": keyDates.unpublished.ONE_DAY_UNTIL_UNPUBLISH,
     "unpublished[PROVIDER_FIVE_WEEKS]": keyDates.unpublished.PROVIDER_FIVE_WEEKS,
     "unpublished[PROVIDER_FOUR_WEEKS]": keyDates.unpublished.PROVIDER_FOUR_WEEKS,
     "unpublished[PROVIDER_THREE_WEEKS]": keyDates.unpublished.PROVIDER_THREE_WEEKS,
     "unpublished[PROVIDER_TWO_WEEKS]": keyDates.unpublished.PROVIDER_TWO_WEEKS,
-    "unpublished[PROVIDER_ONE_WEEK]": keyDates.unpublished.PROVIDER_ONE_WEEK,
+    "unpublished[ONE_WEEK]": keyDates.unpublished.ONE_WEEK,
+    "unpublished[ONE_DAY]": keyDates.unpublished.ONE_DAY,
     "unpublished[UNPUBLISH]": keyDates.unpublished.UNPUBLISH,
   };
 }

--- a/src/server/models/types.ts
+++ b/src/server/models/types.ts
@@ -34,8 +34,8 @@ export interface UnpublishedKeyDates extends JsonObject {
   PROVIDER_FOUR_WEEKS: string;
   PROVIDER_THREE_WEEKS: string;
   PROVIDER_TWO_WEEKS: string;
-  PROVIDER_ONE_WEEK: string;
-  ONE_DAY_UNTIL_UNPUBLISH: string;
+  ONE_WEEK: string;
+  ONE_DAY: string;
   UNPUBLISH: string;
 }
 export interface ScheduledProcessKeyDates extends JsonObject {


### PR DESCRIPTION
Refactored the List.jsonData.currentAnnualReview.keyDates.unpublished key to reflect ONE_WEEK, ONE_DAY and UNPUBLISH apply to both posts and providers.