### PR TITLE
fix: add ISO code for Kosovo and Somaliland

### DIFF
--- a/docker/apply/forms-json/covid-test-providers.json
+++ b/docker/apply/forms-json/covid-test-providers.json
@@ -1399,6 +1399,10 @@
           "value": "Somalia"
         },
         {
+          "text": "Somaliland",
+          "value": "Somaliland"
+        },
+        {
           "text": "South Africa",
           "value": "South Africa"
         },

--- a/docker/apply/forms-json/find-translators-interpreters.json
+++ b/docker/apply/forms-json/find-translators-interpreters.json
@@ -1015,6 +1015,10 @@
           "value": "Somalia"
         },
         {
+          "text": "Somaliland",
+          "value": "Somaliland"
+        },
+        {
           "text": "South Africa",
           "value": "South Africa"
         },

--- a/docker/apply/forms-json/funeral-directors.json
+++ b/docker/apply/forms-json/funeral-directors.json
@@ -1348,6 +1348,10 @@
           "value": "Somalia"
         },
         {
+          "text": "Somaliland",
+          "value": "Somaliland"
+        },
+        {
           "text": "South Africa",
           "value": "South Africa"
         },

--- a/docker/apply/forms-json/lawyers.json
+++ b/docker/apply/forms-json/lawyers.json
@@ -1319,6 +1319,10 @@
           "value": "Somalia"
         },
         {
+          "text": "Somaliland",
+          "value": "Somaliland"
+        },
+        {
           "text": "South Africa",
           "value": "South Africa"
         },

--- a/docker/apply/forms-json/translators-interpreters.json
+++ b/docker/apply/forms-json/translators-interpreters.json
@@ -2237,6 +2237,10 @@
           "value": "Somalia"
         },
         {
+          "text": "Somaliland",
+          "value": "Somaliland"
+        },
+        {
           "text": "South Africa",
           "value": "South Africa"
         },

--- a/src/server/services/metadata.ts
+++ b/src/server/services/metadata.ts
@@ -151,7 +151,7 @@ export const countriesList = [
   { text: "Kazakhstan", value: "Kazakhstan", code: "KAZ" },
   { text: "Kenya", value: "Kenya", code: "KEN" },
   { text: "Kiribati", value: "Kiribati", code: "KIR" },
-  { text: "Kosovo", value: "Kosovo", code: "XKX" },
+  { text: "Kosovo", value: "Kosovo", code: "SRB" },
   { text: "Kuwait", value: "Kuwait", code: "KWT" },
   { text: "Kyrgyzstan", value: "Kyrgyzstan", code: "KGZ" },
   { text: "Laos", value: "Laos", code: "LAO" },
@@ -247,6 +247,7 @@ export const countriesList = [
   { text: "Slovenia", value: "Slovenia", code: "SVN" },
   { text: "Solomon Islands", value: "Solomon Islands", code: "SLB" },
   { text: "Somalia", value: "Somalia", code: "SOM" },
+  { text: "Somaliland", value: "Somaliland", code: "SOM" },
   { text: "South Africa", value: "South Africa", code: "ZAF" },
   {
     text: "South Georgia and South Sandwich Islands",


### PR DESCRIPTION
# Description

The purpose of this PR is to make it possible for user to apply and find their details if they've applied in countries like Kosovo and Somaliland.

Previously the country codes for these countries were incorrect therefore making it difficult for them to be located by the AWS Location services. This PR aims to fix that.

Link to ticket in Trello: https://trello.com/c/VhiQbLN2/1429-add-somaliland-and-kosovo-to-list-of-countries