### PR TITLE
Feat/scheduler start window

### DIFF
--- a/src/scheduler/batch/__tests__/helpers.test.ts
+++ b/src/scheduler/batch/__tests__/helpers.test.ts
@@ -1,4 +1,5 @@
-import {DateContext, getDateContexts, getTodayDate, schedulerMilestoneDays} from "../helpers";
+import { DateContext, getDateContexts, schedulerMilestoneDays } from "../helpers";
+import { startOfDay } from "date-fns";
 
 function testContext(actualUnpublishContext: DateContext[], expectedDateContexts: DateContext[], daysToAction: number) {
   const actualContext = actualUnpublishContext.find((context) => context.eventMilestone === daysToAction);
@@ -100,19 +101,19 @@ describe("Today Date", () => {
   describe("today is GMT timezone", () => {
     jest.useFakeTimers().setSystemTime(new Date("01-Dec-2022 15:37:22.000"));
     const expectedDate = "2022-12-01T00:00:00.000Z";
-    const actualDate = getTodayDate();
+    const actualDate = startOfDay(new Date());
     expect(actualDate.toISOString()).toBe(expectedDate);
   });
   describe("today is BST timezone after midnight", () => {
     jest.useFakeTimers().setSystemTime(new Date("05-May-2023 15:37:22.000"));
     const expectedDate = "2023-05-05T00:00:00.000Z";
-    const actualDate = getTodayDate();
+    const actualDate = startOfDay(new Date());
     expect(actualDate.toISOString()).toBe(expectedDate);
   });
   describe("today is BST timezone after 11pm, before midnight", () => {
     jest.useFakeTimers().setSystemTime(new Date("05-May-2023 23:37:22.000"));
     const expectedDate = "2023-05-05T00:00:00.000Z";
-    const actualDate = getTodayDate();
+    const actualDate = startOfDay(new Date());
     expect(actualDate.toISOString()).toBe(expectedDate);
   });
 });

--- a/src/scheduler/batch/__tests__/helpers.test.ts
+++ b/src/scheduler/batch/__tests__/helpers.test.ts
@@ -10,19 +10,19 @@ describe("Date Contexts", () => {
   describe("annual review date contexts", () => {
     const expectedDateContexts: DateContext[] = [
       {
-        eventDate: new Date(2022, 11, 5, 0, 0, 0),
+        eventDate: new Date(2022, 10, 7, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.post.ONE_MONTH,
       },
       {
-        eventDate: new Date(2022, 11, 26, 0, 0, 0),
+        eventDate: new Date(2022, 10, 28, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.post.ONE_WEEK,
       },
       {
-        eventDate: new Date(2023, 0, 1, 0, 0, 0),
+        eventDate: new Date(2022, 11, 4, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.post.ONE_DAY,
       },
       {
-        eventDate: new Date(2023, 0, 2, 0, 0, 0),
+        eventDate: new Date(2022, 11, 5, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.both.START,
       },
     ];
@@ -45,31 +45,31 @@ describe("Date Contexts", () => {
   describe("unpublished date contexts", () => {
     const expectedDateContexts: DateContext[] = [
       {
-        eventDate: new Date(2023, 0, 9, 0, 0, 0),
+        eventDate: new Date(2022, 11, 12, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.provider.FIVE_WEEKS,
       },
       {
-        eventDate: new Date(2023, 0, 16, 0, 0, 0),
+        eventDate: new Date(2022, 11, 19, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.provider.FOUR_WEEKS,
       },
       {
-        eventDate: new Date(2023, 0, 23, 0, 0, 0),
+        eventDate: new Date(2022, 11, 26, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.provider.THREE_WEEKS,
       },
       {
-        eventDate: new Date(2023, 0, 30, 0, 0, 0),
+        eventDate: new Date(2023, 0, 2, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.provider.TWO_WEEKS,
       },
       {
-        eventDate: new Date(2023, 1, 6, 0, 0, 0),
+        eventDate: new Date(2023, 0, 9, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.both.ONE_WEEK,
       },
       {
-        eventDate: new Date(2023, 1, 12, 0, 0, 0),
+        eventDate: new Date(2023, 0, 15, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.both.ONE_DAY,
       },
       {
-        eventDate: new Date(2023, 1, 13, 0, 0, 0),
+        eventDate: new Date(2023, 0, 16, 0, 0, 0),
         eventMilestone: schedulerMilestoneDays.both.UNPUBLISH,
       },
     ];

--- a/src/scheduler/batch/__tests__/helpers.test.ts
+++ b/src/scheduler/batch/__tests__/helpers.test.ts
@@ -1,4 +1,4 @@
-import { DateContext, getDateContexts, schedulerMilestoneDays } from "../helpers";
+import {DateContext, getDateContexts, getTodayDate, schedulerMilestoneDays} from "../helpers";
 
 function testContext(actualUnpublishContext: DateContext[], expectedDateContexts: DateContext[], daysToAction: number) {
   const actualContext = actualUnpublishContext.find((context) => context.eventMilestone === daysToAction);
@@ -93,5 +93,26 @@ describe("Date Contexts", () => {
       expect(actualContext?.eventMilestone).toBe(expectedContext?.eventMilestone);
       expect(actualContext?.eventDate.toString()).toBe(expectedContext?.eventDate.toString());
     });
+  });
+});
+
+describe("Today Date", () => {
+  describe("today is GMT timezone", () => {
+    jest.useFakeTimers().setSystemTime(new Date("01-Dec-2022 15:37:22.000"));
+    const expectedDate = "2022-12-01T00:00:00.000Z";
+    const actualDate = getTodayDate();
+    expect(actualDate.toISOString()).toBe(expectedDate);
+  });
+  describe("today is BST timezone after midnight", () => {
+    jest.useFakeTimers().setSystemTime(new Date("05-May-2023 15:37:22.000"));
+    const expectedDate = "2023-05-05T00:00:00.000Z";
+    const actualDate = getTodayDate();
+    expect(actualDate.toISOString()).toBe(expectedDate);
+  });
+  describe("today is BST timezone after 11pm, before midnight", () => {
+    jest.useFakeTimers().setSystemTime(new Date("05-May-2023 23:37:22.000"));
+    const expectedDate = "2023-05-05T00:00:00.000Z";
+    const actualDate = getTodayDate();
+    expect(actualDate.toISOString()).toBe(expectedDate);
   });
 });

--- a/src/scheduler/batch/__tests__/main.test.ts
+++ b/src/scheduler/batch/__tests__/main.test.ts
@@ -5,50 +5,50 @@ jest.mock("server/services/logger");
 
 const annualReview: DateContext[] = [
   {
-    eventDate: new Date(2022, 11, 5, 0, 0, 0),
+    eventDate: new Date(2022, 10, 7, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.post.ONE_MONTH,
   },
   {
-    eventDate: new Date(2022, 11, 26, 0, 0, 0),
+    eventDate: new Date(2022, 10, 28, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.post.ONE_WEEK,
   },
   {
-    eventDate: new Date(2023, 0, 1, 0, 0, 0),
+    eventDate: new Date(2022, 11, 4, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.post.ONE_DAY,
   },
   {
-    eventDate: new Date(2023, 0, 2, 0, 0, 0),
+    eventDate: new Date(2022, 11, 5, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.both.START,
   },
 ];
 
 const unpublish: DateContext[] = [
   {
-    eventDate: new Date(2023, 0, 9, 0, 0, 0),
+    eventDate: new Date(2022, 11, 12, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.provider.FIVE_WEEKS,
   },
   {
-    eventDate: new Date(2023, 0, 16, 0, 0, 0),
+    eventDate: new Date(2022, 11, 19, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.provider.FOUR_WEEKS,
   },
   {
-    eventDate: new Date(2023, 0, 23, 0, 0, 0),
+    eventDate: new Date(2022, 11, 26, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.provider.THREE_WEEKS,
   },
   {
-    eventDate: new Date(2023, 0, 30, 0, 0, 0),
+    eventDate: new Date(2023, 0, 2, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.provider.TWO_WEEKS,
   },
   {
-    eventDate: new Date(2023, 1, 6, 0, 0, 0),
+    eventDate: new Date(2023, 0, 9, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.both.ONE_WEEK,
   },
   {
-    eventDate: new Date(2023, 1, 12, 0, 0, 0),
+    eventDate: new Date(2023, 0, 15, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.both.ONE_DAY,
   },
   {
-    eventDate: new Date(2023, 1, 13, 0, 0, 0),
+    eventDate: new Date(2023, 0, 16, 0, 0, 0),
     eventMilestone: schedulerMilestoneDays.both.UNPUBLISH,
   },
 ];

--- a/src/scheduler/batch/helpers.ts
+++ b/src/scheduler/batch/helpers.ts
@@ -54,8 +54,8 @@ export type MilestoneTillAnnualReview = "START" | "POST_ONE_DAY" | "POST_ONE_WEE
  * @param todayDateString
  * @returns UnpublishedDateContext[]
  */
-function getUnpublishedDateContexts(today: Date): DateContext[] {
-  const unpublishedDateSixWeeksAway = addDays(today, (schedulerMilestoneDays.provider.SIX_WEEKS + schedulerMilestoneDays.post.ONE_MONTH));
+function getUnpublishedDateContexts(annualReviewStartDate: Date): DateContext[] {
+  const unpublishedDateSixWeeksAway = addDays(annualReviewStartDate, (schedulerMilestoneDays.provider.SIX_WEEKS));
   const unpublishedDateOneDayAway = subDays(unpublishedDateSixWeeksAway, 1);
 
   const unpublishedDateContextsForFiltering: DateContext[] = [
@@ -71,49 +71,47 @@ function getUnpublishedDateContexts(today: Date): DateContext[] {
 
   // fill in the dates between 1 to 5 weeks from the todayDateString
   for (
-    let daysBeforeEvent = schedulerMilestoneDays.both.ONE_WEEK;
-    daysBeforeEvent <= schedulerMilestoneDays.provider.FIVE_WEEKS;
-    daysBeforeEvent += 7
+    let eventMilestone = schedulerMilestoneDays.both.ONE_WEEK;
+    eventMilestone <= schedulerMilestoneDays.provider.FIVE_WEEKS;
+    eventMilestone += 7
   ) {
-    const localUnpublishDate = subDays(unpublishedDateSixWeeksAway, daysBeforeEvent);
-    const unpublishDate = new Date(localUnpublishDate.getFullYear(), localUnpublishDate.getMonth(), localUnpublishDate.getDate(), 0, 0, 0);
-    const eventDate = new Date(unpublishDate.getFullYear(), unpublishDate.getMonth(), unpublishDate.getDate(), 0, 0, 0);
+    const localEventDate = subDays(unpublishedDateSixWeeksAway, eventMilestone);
+    const eventDate = new Date(localEventDate.getFullYear(), localEventDate.getMonth(), localEventDate.getDate(), 0, 0, 0);
     unpublishedDateContextsForFiltering.push({
       eventDate,
-      eventMilestone: daysBeforeEvent,
+      eventMilestone,
     });
   }
   return unpublishedDateContextsForFiltering;
 }
 
-function getAnnualReviewDateContexts(today: Date): DateContext[] {
-  const annualReviewStart = addDays(today, schedulerMilestoneDays.post.ONE_MONTH);
+function getAnnualReviewDateContexts(annualReviewStartDate: Date): DateContext[] {
 
   const annualReview: DateContext[] = [
     {
       eventMilestone: schedulerMilestoneDays.post.ONE_MONTH,
-      eventDate: today,
+      eventDate: subDays(annualReviewStartDate, schedulerMilestoneDays.post.ONE_MONTH),
     },
     {
       eventMilestone: schedulerMilestoneDays.post.ONE_DAY,
-      eventDate: subDays(annualReviewStart, schedulerMilestoneDays.post.ONE_DAY),
+      eventDate: subDays(annualReviewStartDate, schedulerMilestoneDays.post.ONE_DAY),
     },
     {
       eventMilestone: schedulerMilestoneDays.post.ONE_WEEK,
-      eventDate: subDays(annualReviewStart, schedulerMilestoneDays.post.ONE_WEEK),
+      eventDate: subDays(annualReviewStartDate, schedulerMilestoneDays.post.ONE_WEEK),
     },
     {
       eventMilestone: schedulerMilestoneDays.both.START,
-      eventDate: annualReviewStart,
+      eventDate: annualReviewStartDate,
     },
   ];
   return annualReview;
 }
 
-export function getDateContexts(today: Date): SchedulerDateContexts {
+export function getDateContexts(annualReviewStartDate: Date): SchedulerDateContexts {
   return {
-    annualReview: getAnnualReviewDateContexts(today),
-    unpublish: getUnpublishedDateContexts(today),
+    annualReview: getAnnualReviewDateContexts(annualReviewStartDate),
+    unpublish: getUnpublishedDateContexts(annualReviewStartDate),
   };
 }
 

--- a/src/scheduler/batch/helpers.ts
+++ b/src/scheduler/batch/helpers.ts
@@ -206,3 +206,8 @@ export function getDateForContext(
   }
   return dateContext;
 }
+
+export function getTodayDate() {
+  const localDate = new Date();
+  return new Date(Date.UTC(localDate.getFullYear(), localDate.getMonth(), localDate.getDate(), 0, 0, 0));
+}

--- a/src/scheduler/batch/helpers.ts
+++ b/src/scheduler/batch/helpers.ts
@@ -1,4 +1,4 @@
-import { addDays, subDays } from "date-fns";
+import { addDays, startOfDay, subDays } from "date-fns";
 import { CurrentAnnualReview } from "server/models/types";
 import crypto from "crypto";
 
@@ -55,7 +55,7 @@ export type MilestoneTillAnnualReview = "START" | "POST_ONE_DAY" | "POST_ONE_WEE
  * @returns UnpublishedDateContext[]
  */
 function getUnpublishedDateContexts(annualReviewStartDate: Date): DateContext[] {
-  const unpublishedDateSixWeeksAway = addDays(annualReviewStartDate, (schedulerMilestoneDays.provider.SIX_WEEKS));
+  const unpublishedDateSixWeeksAway = addDays(annualReviewStartDate, schedulerMilestoneDays.provider.SIX_WEEKS);
   const unpublishedDateOneDayAway = subDays(unpublishedDateSixWeeksAway, 1);
 
   const unpublishedDateContextsForFiltering: DateContext[] = [
@@ -75,10 +75,10 @@ function getUnpublishedDateContexts(annualReviewStartDate: Date): DateContext[] 
     eventMilestone <= schedulerMilestoneDays.provider.FIVE_WEEKS;
     eventMilestone += 7
   ) {
-    const localEventDate = subDays(unpublishedDateSixWeeksAway, eventMilestone);
-    const eventDate = new Date(localEventDate.getFullYear(), localEventDate.getMonth(), localEventDate.getDate(), 0, 0, 0);
+    const eventDate = subDays(unpublishedDateSixWeeksAway, eventMilestone);
+    const startOfEventDate = startOfDay(eventDate);
     unpublishedDateContextsForFiltering.push({
-      eventDate,
+      eventDate: startOfEventDate,
       eventMilestone,
     });
   }
@@ -86,7 +86,6 @@ function getUnpublishedDateContexts(annualReviewStartDate: Date): DateContext[] 
 }
 
 function getAnnualReviewDateContexts(annualReviewStartDate: Date): DateContext[] {
-
   const annualReview: DateContext[] = [
     {
       eventMilestone: schedulerMilestoneDays.post.ONE_MONTH,
@@ -115,10 +114,7 @@ export function getDateContexts(annualReviewStartDate: Date): SchedulerDateConte
   };
 }
 
-export function getCurrentAnnualReviewData(
-  listItemIdsForAnnualReview: any[],
-  contexts: SchedulerDateContexts
-) {
+export function getCurrentAnnualReviewData(listItemIdsForAnnualReview: any[], contexts: SchedulerDateContexts) {
   const currentAnnualReview: CurrentAnnualReview = {
     reference: crypto.randomUUID(),
     eligibleListItems: listItemIdsForAnnualReview,
@@ -139,11 +135,7 @@ export function getCurrentAnnualReviewData(
           "annualReview",
           schedulerMilestoneDays.post.ONE_DAY
         ).eventDate.toISOString(),
-        START: getDateForContext(
-          contexts,
-          "annualReview",
-          schedulerMilestoneDays.both.START
-        ).eventDate.toISOString(),
+        START: getDateForContext(contexts, "annualReview", schedulerMilestoneDays.both.START).eventDate.toISOString(),
       },
       unpublished: {
         PROVIDER_FIVE_WEEKS: getDateForContext(
@@ -171,11 +163,7 @@ export function getCurrentAnnualReviewData(
           "unpublish",
           schedulerMilestoneDays.both.ONE_WEEK
         ).eventDate.toISOString(),
-        ONE_DAY: getDateForContext(
-          contexts,
-          "unpublish",
-          schedulerMilestoneDays.both.ONE_DAY
-        ).eventDate.toISOString(),
+        ONE_DAY: getDateForContext(contexts, "unpublish", schedulerMilestoneDays.both.ONE_DAY).eventDate.toISOString(),
         UNPUBLISH: getDateForContext(
           contexts,
           "unpublish",
@@ -187,11 +175,7 @@ export function getCurrentAnnualReviewData(
   return currentAnnualReview;
 }
 
-export function getDateForContext(
-  contexts: SchedulerDateContexts,
-  contextType: string,
-  milestone: SchedulerMilestone
-) {
+export function getDateForContext(contexts: SchedulerDateContexts, contextType: string, milestone: SchedulerMilestone) {
   let dateContext;
   switch (contextType) {
     case "annualReview":
@@ -207,7 +191,3 @@ export function getDateForContext(
   return dateContext;
 }
 
-export function getTodayDate() {
-  const localDate = new Date();
-  return new Date(Date.UTC(localDate.getFullYear(), localDate.getMonth(), localDate.getDate(), 0, 0, 0));
-}

--- a/src/scheduler/batch/main.ts
+++ b/src/scheduler/batch/main.ts
@@ -39,6 +39,7 @@ export async function populateCurrentAnnualReview(
     } else {
       const listItemIdsForAnnualReview = listItemsEligibleForAnnualReview.map((listItem) => listItem.id);
       const currentAnnualReview = getCurrentAnnualReviewData(listItemIdsForAnnualReview, contexts);
+
       await updateListForAnnualReview(list, { currentAnnualReview });
     }
   }
@@ -53,11 +54,7 @@ export async function updateListsForAnnualReview(todayDateString: string): Promi
     helpers.schedulerMilestoneDays.both.START
   );
   if (annualReviewStartContext) {
-    // @todo also get the lists without an annual review date that were first published 1 year ago. Only needed if List.annualReviewStartDate not populated
-    const { result } = await findListByAnnualReviewDate(annualReviewStartContext.eventDate);
-
-    // exclude lists that already have currentAnnualReview populated
-    const lists = result?.filter(list => !list.jsonData.currentAnnualReview?.eligibleListItems);
+    const { result: lists } = await findListByAnnualReviewDate(annualReviewStartContext.eventDate, today);
 
     logger.info(`Found ${lists?.length} Lists matching annual review start date [${annualReviewStartContext.eventDate}]`);
     if (!lists?.length) {

--- a/src/scheduler/batch/main.ts
+++ b/src/scheduler/batch/main.ts
@@ -64,7 +64,7 @@ export async function populateCurrentAnnualReview(lists: List[]): Promise<void> 
 export async function updateListsForAnnualReview(today: Date): Promise<void> {
   const annualReviewStartDate = addDays(today, schedulerMilestoneDays.post.ONE_MONTH);
   if (annualReviewStartDate) {
-    const { result: lists } = await findListByAnnualReviewDate(annualReviewStartDate, today);
+    const { result: lists } = await findListByAnnualReviewDate(annualReviewStartDate);
 
     logger.info(
       `Found the lists ${lists?.map((list) => list.id)} matching annual review start date [${annualReviewStartDate}]`

--- a/src/scheduler/batch/main.ts
+++ b/src/scheduler/batch/main.ts
@@ -3,14 +3,12 @@ import { List } from "server/models/types";
 import { logger } from "server/services/logger";
 import { findListItems } from "server/models/listItem";
 import * as helpers from "./helpers";
-import {getCurrentAnnualReviewData, getTodayDate, schedulerMilestoneDays} from "./helpers";
+import { getCurrentAnnualReviewData, schedulerMilestoneDays } from "./helpers";
 import { ListItemWithHistory } from "server/components/dashboard/listsItems/types";
-import {addDays} from "date-fns";
+import { addDays, startOfDay } from "date-fns";
 import _ from "lodash";
 
-export async function populateCurrentAnnualReview(
-  lists: List[]
-): Promise<void> {
+export async function populateCurrentAnnualReview(lists: List[]): Promise<void> {
   const listIds = lists.map((list) => list.id);
   const findListItemsResult = await findListItems({
     listIds,
@@ -48,7 +46,8 @@ export async function populateCurrentAnnualReview(
         const { eligibleListItems: newEligibileListItems } = currentAnnualReview;
         isUpdateList = !_.isEqual(
           currentEligibileListItems.sort((a, b) => a - b),
-          newEligibileListItems.sort((a, b) => a - b));
+          newEligibileListItems.sort((a, b) => a - b)
+        );
         if (isUpdateList) {
           currentAnnualReview.reference = list.jsonData.currentAnnualReview.reference;
           currentAnnualReview.keyDates = list.jsonData.currentAnnualReview.keyDates;
@@ -56,20 +55,21 @@ export async function populateCurrentAnnualReview(
       }
 
       if (isUpdateList) {
-        await updateListForAnnualReview(list, {currentAnnualReview});
+        await updateListForAnnualReview(list, { currentAnnualReview });
       }
     }
   }
 }
 
 export async function updateListsForAnnualReview(today: Date): Promise<void> {
-  const annualReviewStartDate = addDays(today, schedulerMilestoneDays.post.ONE_MONTH)
+  const annualReviewStartDate = addDays(today, schedulerMilestoneDays.post.ONE_MONTH);
   if (annualReviewStartDate) {
     const { result: lists } = await findListByAnnualReviewDate(annualReviewStartDate, today);
 
-    logger.info(`Found ${lists?.length} Lists matching annual review start date [${annualReviewStartDate}]`);
+    logger.info(
+      `Found the lists ${lists?.map((list) => list.id)} matching annual review start date [${annualReviewStartDate}]`
+    );
     if (!lists?.length) {
-      logger.info(`No lists found for annual review date ${annualReviewStartDate}`);
       return;
     }
     // @ts-ignore
@@ -83,7 +83,7 @@ export async function updateListsForAnnualReview(today: Date): Promise<void> {
  *    todayDateString = formatDate(subDays(new Date(), 27)); // today is day before annual review start date
  *    todayDateString = formatDate(subDays(new Date(), 21)); // today is one week before annual review start date
  */
-updateListsForAnnualReview( getTodayDate())
+updateListsForAnnualReview(startOfDay(new Date()))
   .then((r) => {
     logger.info(`Batch scheduler finished`);
     process.exit(0);

--- a/src/scheduler/batch/main.ts
+++ b/src/scheduler/batch/main.ts
@@ -2,9 +2,8 @@ import { findListByAnnualReviewDate, updateListForAnnualReview } from "server/mo
 import { List } from "server/models/types";
 import { logger } from "server/services/logger";
 import { findListItems } from "server/models/listItem";
-import { SCHEDULED_PROCESS_TODAY_DATE } from "server/config";
 import * as helpers from "./helpers";
-import {getCurrentAnnualReviewData, schedulerMilestoneDays} from "./helpers";
+import {getCurrentAnnualReviewData, getTodayDate, schedulerMilestoneDays} from "./helpers";
 import { ListItemWithHistory } from "server/components/dashboard/listsItems/types";
 import {addDays} from "date-fns";
 import _ from "lodash";
@@ -63,8 +62,7 @@ export async function populateCurrentAnnualReview(
   }
 }
 
-export async function updateListsForAnnualReview(todayDateString: string): Promise<void> {
-  const today = new Date(todayDateString);
+export async function updateListsForAnnualReview(today: Date): Promise<void> {
   const annualReviewStartDate = addDays(today, schedulerMilestoneDays.post.ONE_MONTH)
   if (annualReviewStartDate) {
     const { result: lists } = await findListByAnnualReviewDate(annualReviewStartDate, today);
@@ -85,8 +83,7 @@ export async function updateListsForAnnualReview(todayDateString: string): Promi
  *    todayDateString = formatDate(subDays(new Date(), 27)); // today is day before annual review start date
  *    todayDateString = formatDate(subDays(new Date(), 21)); // today is one week before annual review start date
  */
-const todayDateString = SCHEDULED_PROCESS_TODAY_DATE;
-updateListsForAnnualReview(todayDateString)
+updateListsForAnnualReview( getTodayDate())
   .then((r) => {
     logger.info(`Batch scheduler finished`);
     process.exit(0);

--- a/src/server/components/annual-review/controller.ts
+++ b/src/server/components/annual-review/controller.ts
@@ -14,6 +14,7 @@ import { logger } from "server/services/logger";
 import type { ListItemGetObject, List } from "server/models/types";
 import { EVENTS } from "server/models/listItem/listItemEvent";
 import { initialiseFormRunnerSession } from "server/components/formRunner/helpers";
+import {sendAnnualReviewCompletedEmailForList} from "server/components/annual-review/helpers";
 
 export async function confirmGetController(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
@@ -157,7 +158,7 @@ export async function declarationPostController(req: Request, res: Response, nex
       return res.redirect(`/annual-review/declaration/${listItemRef}`);
     }
 
-    await prisma.listItem.update({
+    const updatedListItem = await prisma.listItem.update({
       where: { reference: listItemRef },
       data: {
         status: Status.CHECK_ANNUAL_REVIEW,
@@ -166,7 +167,7 @@ export async function declarationPostController(req: Request, res: Response, nex
         },
       },
     });
-
+    await sendAnnualReviewCompletedEmailForList(updatedListItem.listId);
     res.redirect("/annual-review/submitted");
   } catch (err) {
     next(err);

--- a/src/server/components/annual-review/helpers.ts
+++ b/src/server/components/annual-review/helpers.ts
@@ -8,7 +8,7 @@ export async function sendAnnualReviewCompletedEmailForList(listId: number) {
   if (list?.jsonData?.users) {
     await Promise.all(
       list.jsonData.users.map(async (postEmailAddress: string) => {
-        await sendAnnualReviewCompletedEmail(
+        return await sendAnnualReviewCompletedEmail(
           postEmailAddress,
           lowerCase(startCase(list.type)),
           list?.country?.name ?? ""

--- a/src/server/components/annual-review/helpers.ts
+++ b/src/server/components/annual-review/helpers.ts
@@ -1,0 +1,19 @@
+import { findListById } from "server/models/list";
+import { sendAnnualReviewCompletedEmail } from "server/services/govuk-notify";
+import { lowerCase, startCase } from "lodash";
+
+export async function sendAnnualReviewCompletedEmailForList(listId: number) {
+  const list = await findListById(listId);
+
+  if (list?.jsonData?.users) {
+    await Promise.all(
+      list.jsonData.users.map(async (postEmailAddress: string) => {
+        await sendAnnualReviewCompletedEmail(
+          postEmailAddress,
+          lowerCase(startCase(list.type)),
+          list?.country?.name ?? ""
+        );
+      })
+    );
+  }
+}

--- a/src/server/components/auth/helpers.ts
+++ b/src/server/components/auth/helpers.ts
@@ -25,6 +25,15 @@ export function ensureUserIsAdministrator(req: Request, res: Response, next: Nex
   }
 }
 
+export function onlyAllowAdminsEditAnnualReviewDate(req: Request, res: Response, next: NextFunction) {
+  if(req.user?.isAdministrator) {
+    return next();
+  }
+
+  req.flash("error", "You do not have permissions to edit the annual review date");
+  return res.redirect(res?.locals.listsEditUrl);
+}
+
 export async function initAuth(server: Express): Promise<void> {
   await configureExpressSession(server);
   await configurePassport(server);

--- a/src/server/components/dashboard/annualReview/controllers.ts
+++ b/src/server/components/dashboard/annualReview/controllers.ts
@@ -11,8 +11,6 @@ import type { NextFunction, Request, Response } from "express";
 import type { List } from "server/models/types";
 import { updateAnnualReviewWithKeyDates } from "server/components/dashboard/annualReview/helpers.keyDates";
 import {isAfter, isEqual} from "date-fns";
-import {UserRoles} from "server/models/types";
-import {HttpException} from "server/middlewares/error-handlers";
 
 export const DATE_FORMAT = "d MMMM yyyy";
 

--- a/src/server/components/dashboard/annualReview/controllers.ts
+++ b/src/server/components/dashboard/annualReview/controllers.ts
@@ -66,11 +66,6 @@ async function confirmNewAnnualReviewDate(req: Request, res: Response, next: Nex
     return res.redirect(`${res.locals.listsEditUrl}/annual-review-date`);
   }
 
-  const roles = req.user?.userData?.jsonData.roles;
-  if (roles && !roles.includes(UserRoles.Administrator)) {
-    logger.warn(`non-admin user ${req.user?.userData.id} attempted to edit annual review start date`);
-    return next(new HttpException(405, "405", "You do not have access to edit the annual review start date"));
-  }
   return res.render("dashboard/lists-edit-annual-review-date-confirm", {
     ...DEFAULT_VIEW_PROPS,
     newAnnualReviewDateFormatted: DateFns.format(annualReviewDate.value, DATE_FORMAT),

--- a/src/server/components/dashboard/listsItems/itemsRouter.ts
+++ b/src/server/components/dashboard/listsItems/itemsRouter.ts
@@ -18,6 +18,7 @@ import { findListItemById } from "server/models/listItem";
 import { HttpException } from "server/middlewares/error-handlers";
 import { updateRouter } from "./item/update/updateRouter";
 import { validateAccessToList } from "server/components/dashboard/listsItems/validateAccessToList";
+import {onlyAllowAdminsEditAnnualReviewDate} from "server/components/auth/helpers";
 
 export const listRouter = express.Router();
 
@@ -95,5 +96,5 @@ listRouter.use("/:listId/items/:listItemId", updateRouter);
 
 listRouter.post("/:listId/publisher-delete", controllers.listPublisherDelete);
 
-listRouter.get("/:listId/annual-review-date", annualReview.editDateGetController);
-listRouter.post("/:listId/annual-review-date", annualReview.editDatePostController);
+listRouter.get("/:listId/annual-review-date", onlyAllowAdminsEditAnnualReviewDate, annualReview.editDateGetController);
+listRouter.post("/:listId/annual-review-date", onlyAllowAdminsEditAnnualReviewDate, annualReview.editDatePostController);

--- a/src/server/components/lists/controllers/ingest/ingestPutController.ts
+++ b/src/server/components/lists/controllers/ingest/ingestPutController.ts
@@ -10,6 +10,7 @@ import { deserialise } from "server/models/listItem/listItemCreateInputFromWebho
 import { getServiceTypeName } from "server/components/lists/helpers";
 import { EVENTS } from "server/models/listItem/listItemEvent";
 import { getObjectDiff } from "./helpers";
+import {sendAnnualReviewCompletedEmailForList} from "server/components/annual-review/helpers";
 
 export async function ingestPutController(req: Request, res: Response) {
   const id = req.params.id;
@@ -82,6 +83,8 @@ export async function ingestPutController(req: Request, res: Response) {
         AuditEvent.EDITED
       ),
     ]);
+
+    await sendAnnualReviewCompletedEmailForList(listItem.listId);
 
     return res.status(204).send();
   } catch (e) {

--- a/src/server/config/server-config.ts
+++ b/src/server/config/server-config.ts
@@ -49,11 +49,6 @@ export const NOTIFY = {
   },
 };
 
-// Scheduled process
-const options: Intl.DateTimeFormatOptions = { day: "2-digit", month: "short", year: "numeric" };
-const defaultTodayDateString = new Date().toLocaleString("en-gb", options);
-export const SCHEDULED_PROCESS_TODAY_DATE = process.env.SCHEDULED_PROCESS_TODAY_DATE ?? defaultTodayDateString;
-
 // Form runner
 export const FORM_RUNNER_URL = process.env.FORM_RUNNER_URL ?? "apply:3001";
 export const FORM_RUNNER_PUBLIC_URL = `${SERVICE_DOMAIN}/application`;

--- a/src/server/config/server-config.ts
+++ b/src/server/config/server-config.ts
@@ -37,6 +37,7 @@ export const NOTIFY = {
       postOneDay: process.env.GOVUK_NOTIFY_ANNUAL_REVIEW_POST_ONE_DAY_NOTICE?.trim() ?? "",
       postStart: process.env.GOVUK_NOTIFY_ANNUAL_REVIEW_POST_STARTED?.trim() ?? "",
       providerStart: process.env.GOVUK_NOTIFY_ANNUAL_REVIEW_PROVIDER_STARTED?.trim() ?? "",
+      annualReviewCompleted: process.env.GOVUK_NOTIFY_ANNUAL_REVIEW_POST_COMPLETED?.trim() ?? "",
     },
     unpublishNotice: {
       postWeekly: process.env.GOVUK_NOTIFY_UNPUBLISH_POST_WEEKLY_NOTICE?.trim() ?? "",

--- a/src/server/models/list.ts
+++ b/src/server/models/list.ts
@@ -5,7 +5,6 @@ import { prisma } from "./db/prisma-client";
 
 import { CountryName, CurrentAnnualReview, List, ListCreateInput, ListUpdateInput, ServiceType } from "./types";
 import { subMonths } from "date-fns";
-import { Status } from "@prisma/client";
 
 export async function findListById(listId: string | number): Promise<List | undefined> {
   try {
@@ -44,19 +43,13 @@ export async function findListByCountryAndType(country: CountryName, type: Servi
   }
 }
 
-export async function findListByAnnualReviewDate(
-  annualReviewStartDate: Date,
-  fromDate: Date,
-  listItemStatuses: Status[] = [],
-  isAnnualReview?: boolean
-): Promise<Result<List[]>> {
+export async function findListByAnnualReviewDate(annualReviewStartDate: Date): Promise<Result<List[]>> {
   try {
     logger.debug(`searching for lists matching date [${annualReviewStartDate}]`);
 
     const result = (await prisma.list.findMany({
       where: {
         nextAnnualReviewStartDate: {
-          gte: fromDate,
           lte: annualReviewStartDate,
         },
       },
@@ -64,8 +57,6 @@ export async function findListByAnnualReviewDate(
         country: true,
         items: {
           where: {
-            ...(listItemStatuses.length && { status: { in: listItemStatuses } }),
-            ...(isAnnualReview !== undefined && { isAnnualReview }),
             history: {
               some: {
                 type: "PUBLISHED",

--- a/src/server/models/list.ts
+++ b/src/server/models/list.ts
@@ -1,11 +1,11 @@
-import {compact, toLower, trim} from "lodash";
-import {logger} from "server/services/logger";
-import {isGovUKEmailAddress} from "server/utils/validation";
-import {prisma} from "./db/prisma-client";
+import { compact, toLower, trim } from "lodash";
+import { logger } from "server/services/logger";
+import { isGovUKEmailAddress } from "server/utils/validation";
+import { prisma } from "./db/prisma-client";
 
-import {CountryName, CurrentAnnualReview, List, ListCreateInput, ListUpdateInput, ServiceType} from "./types";
-import {subMonths} from "date-fns";
-import {Status} from "@prisma/client";
+import { CountryName, CurrentAnnualReview, List, ListCreateInput, ListUpdateInput, ServiceType } from "./types";
+import { subMonths } from "date-fns";
+import { Status } from "@prisma/client";
 
 export async function findListById(listId: string | number): Promise<List | undefined> {
   try {
@@ -44,14 +44,19 @@ export async function findListByCountryAndType(country: CountryName, type: Servi
   }
 }
 
-export async function findListByAnnualReviewDate(annualReviewStartDate: Date, today: Date, listItemStatuses: Status[] = [], isAnnualReview?: boolean): Promise<Result<List[]>> {
+export async function findListByAnnualReviewDate(
+  annualReviewStartDate: Date,
+  fromDate: Date,
+  listItemStatuses: Status[] = [],
+  isAnnualReview?: boolean
+): Promise<Result<List[]>> {
   try {
     logger.debug(`searching for lists matching date [${annualReviewStartDate}]`);
 
     const result = (await prisma.list.findMany({
       where: {
         nextAnnualReviewStartDate: {
-          gte: today,
+          gte: fromDate,
           lte: annualReviewStartDate,
         },
       },
@@ -59,13 +64,13 @@ export async function findListByAnnualReviewDate(annualReviewStartDate: Date, to
         country: true,
         items: {
           where: {
-            ...(listItemStatuses.length && { status: { in: listItemStatuses }}),
+            ...(listItemStatuses.length && { status: { in: listItemStatuses } }),
             ...(isAnnualReview !== undefined && { isAnnualReview }),
             history: {
               some: {
                 type: "PUBLISHED",
                 time: {
-                  lte: subMonths(Date.now(), 1)
+                  lte: subMonths(Date.now(), 1),
                 },
               },
             },

--- a/src/server/services/govuk-notify.ts
+++ b/src/server/services/govuk-notify.ts
@@ -160,6 +160,27 @@ export async function sendAnnualReviewDateChangeEmail(options: {
   }
 }
 
+export async function sendAnnualReviewCompletedEmail(
+  emailAddress: string,
+  typePlural: string,
+  country: string): Promise<void> {
+  try {
+    if (config.isSmokeTest) {
+      logger.info(`isSmokeTest[${config.isSmokeTest}]`);
+      return;
+    }
+
+    const personalisation = {
+      typeSingular: pluralize.singular(typePlural),
+      country,
+    };
+    logger.info(`personalisation for sendAnnualReviewCompletedEmail: ${JSON.stringify(personalisation)}, API key ${NOTIFY.apiKey}, email address ${emailAddress}`);
+    await getNotifyClient().sendEmail(NOTIFY.templates.annualReviewNotices.annualReviewCompleted, emailAddress, { personalisation });
+  } catch (error) {
+    logger.error(`The annual review completion email could not be sent due to error: ${(error as Error).message}`);
+  }
+}
+
 export async function sendAnnualReviewPostEmail(
   milestoneTillAnnualReviewStart: MilestoneTillAnnualReview,
   emailAddress: string,

--- a/src/server/views/dashboard/lists-edit.njk
+++ b/src/server/views/dashboard/lists-edit.njk
@@ -41,11 +41,13 @@
             <dd class="govuk-summary-list__value" data-testid="annual-review-date">
               {{ annualReviewStartDate }}
             </dd>
+            {% if user?.jsonData?.roles.includes('Administrator') %}
             <dd class="govuk-summary-list__actions">
               <a class="govuk-link" href="{{ dashboardRoutes.listsEditAnnualReviewDate.replace(':listId', list.id) }}">
                 Change<span class="govuk-visually-hidden"> date</span>
               </a>
             </dd>
+            {% endif %}
           </div>
         </dl>
       </div>

--- a/src/server/views/dashboard/lists-edit.njk
+++ b/src/server/views/dashboard/lists-edit.njk
@@ -41,7 +41,7 @@
             <dd class="govuk-summary-list__value" data-testid="annual-review-date">
               {{ annualReviewStartDate }}
             </dd>
-            {% if user?.jsonData?.roles.includes('Administrator') %}
+            {% if user.jsonData.roles.includes('Administrator') %}
             <dd class="govuk-summary-list__actions">
               <a class="govuk-link" href="{{ dashboardRoutes.listsEditAnnualReviewDate.replace(':listId', list.id) }}">
                 Change<span class="govuk-visually-hidden"> date</span>

--- a/src/server/views/errors/generic-error.njk
+++ b/src/server/views/errors/generic-error.njk
@@ -12,6 +12,8 @@
               Page not found
             {% elif status == 429 %}
               You have exceeded the maximum rate of page requests
+            {% elif status == 405 %}
+              Access denied
             {% else %}
               Sorry, there is a problem with the service
             {% endif %}

--- a/src/server/views/errors/generic-error.njk
+++ b/src/server/views/errors/generic-error.njk
@@ -12,8 +12,6 @@
               Page not found
             {% elif status == 429 %}
               You have exceeded the maximum rate of page requests
-            {% elif status == 405 %}
-              Access denied
             {% else %}
               Sorry, there is a problem with the service
             {% endif %}


### PR DESCRIPTION
This PR includes the following changes:

- scheduler batch process only updates currentAnnualReview if it does not already exist or if the retrieved eligibleListItems differs to the existing ones populated.  If this is the case then the eligibleListItems and the key dates are updated but the annualReviewRef is left intact to allow identification of audit records for previous emails being sent out. 
- scheduler worker process updated to email after milestone date before annual review start has arrived or passed.
- prevent currentAnnualReviewKeyDates being updated when changing next annual review start date after annual review has already started
- email sent to consular post members of a list after annual review is completed by the provider for a given list item 

### Steps to test:

**Email windows**
- one month window: set the POST_ONE_MONTH date < 28 days but > 7 days away
- wait for the email to be sent out
- do the same for POST_ONE_WEEK date (< 7 days > 1 day from annual review start date)

**Updating key dates**
- set the next annual review start date from the list settings page
- view the key dates from the /development endpoint
- change the annual review start date to another value < 28 days away
- see the key dates get updated in the /development endpoint
- set the annual review START key date to today and wait for the email to be sent by the scheduler
- now change the next annual review start date from the list settings 
- the key dates should not have been updated when checking in the /development endpoint

**Emails to post on annual review completion**
- trigger the annual review emails to the providers
- open the magic link in the email in an incognito browser window
- select the no changes option to complete the annual review and an email should be sent to the members of the list
- open another magic link from a different email in an incognito browser window
- make changes to the provider details and submit and you should find an email gets sent to the members of the list.