### PR TITLE
feat: upgrade Docker image to the latest version of Node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # if you are on Mac M1 please add --platform=linux/amd64 after FROM below
-FROM node:14.17-alpine3.13 AS base
+FROM node:14.21-alpine3.13 AS base
 RUN mkdir -p /usr/src/app && \
     addgroup -g 1001 appuser && \
     adduser -S -u 1001 -G appuser appuser && \
@@ -46,7 +46,7 @@ CMD ["npm", "run", "start:prod"]
 
 # docker build --target main -t scheduled --build-arg BUILD_MODE=ci .
 # if you are on Mac M1 please add --platform=linux/amd64 after FROM below
-FROM node:14.17-alpine3.13 AS scheduled
+FROM node:14.21-alpine3.13 AS scheduled
 WORKDIR /usr/src/scheduler
 COPY --from=main /usr/src/app/dist ./dist/
 COPY --from=main /usr/src/app/node_modules ./node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # if you are on Mac M1 please add --platform=linux/amd64 after FROM below
-FROM node:14.21-alpine3.13 AS base
+FROM node:14-alpine AS base
 RUN mkdir -p /usr/src/app && \
     addgroup -g 1001 appuser && \
     adduser -S -u 1001 -G appuser appuser && \
@@ -46,7 +46,7 @@ CMD ["npm", "run", "start:prod"]
 
 # docker build --target main -t scheduled --build-arg BUILD_MODE=ci .
 # if you are on Mac M1 please add --platform=linux/amd64 after FROM below
-FROM node:14.21-alpine3.13 AS scheduled
+FROM node:14-alpine AS scheduled
 WORKDIR /usr/src/scheduler
 COPY --from=main /usr/src/app/dist ./dist/
 COPY --from=main /usr/src/app/node_modules ./node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # if you are on Mac M1 please add --platform=linux/amd64 after FROM below
-FROM node:16-alpine AS base
+FROM node:14-alpine AS base
 RUN mkdir -p /usr/src/app && \
     addgroup -g 1001 appuser && \
     adduser -S -u 1001 -G appuser appuser && \
@@ -46,7 +46,7 @@ CMD ["npm", "run", "start:prod"]
 
 # docker build --target main -t scheduled --build-arg BUILD_MODE=ci .
 # if you are on Mac M1 please add --platform=linux/amd64 after FROM below
-FROM node:16-alpine AS scheduled
+FROM node:14-alpine AS scheduled
 WORKDIR /usr/src/scheduler
 COPY --from=main /usr/src/app/dist ./dist/
 COPY --from=main /usr/src/app/node_modules ./node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # if you are on Mac M1 please add --platform=linux/amd64 after FROM below
-FROM node:14-alpine AS base
+FROM node:16-alpine AS base
 RUN mkdir -p /usr/src/app && \
     addgroup -g 1001 appuser && \
     adduser -S -u 1001 -G appuser appuser && \
@@ -46,7 +46,7 @@ CMD ["npm", "run", "start:prod"]
 
 # docker build --target main -t scheduled --build-arg BUILD_MODE=ci .
 # if you are on Mac M1 please add --platform=linux/amd64 after FROM below
-FROM node:14-alpine AS scheduled
+FROM node:16-alpine AS scheduled
 WORKDIR /usr/src/scheduler
 COPY --from=main /usr/src/app/dist ./dist/
 COPY --from=main /usr/src/app/node_modules ./node_modules/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-development",
   "private": true,
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "scripts": {
     "dev": "npm run prisma:generate && webpack",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-development",
   "private": true,
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "scripts": {
     "dev": "npm run prisma:generate && webpack",


### PR DESCRIPTION
# Description

The purpose of this PR is to change the image of NodeJS in Docker to a version that is supported.

NodeJS v14 is only supported up until June 2023, so we will have to upgrade to 16 at some point soon.

Link to ticket in Trello: https://trello.com/c/MsfxOQr8/1601-high-fcdo-014-2-1-inf-000153-outdated-and-unsupported-base-image