### PR TITLE
Feat/annual review smoke tests

### DIFF
--- a/cypress/e2e/annual-review/banner-today.feature
+++ b/cypress/e2e/annual-review/banner-today.feature
@@ -1,11 +1,17 @@
 Feature: Annual review banners
 
-  Background:
-    Given I am logged in as a "User"
-    And A "lawyers" list exists for Eurasia
-    And eurasia lawyers have annual review today
-    When the batch process has run
-    And I am viewing list item index for reference:SMOKE
+    Background:
+        Given I am logged in as a "User"
+        And A "lawyers" list exists for Eurasia
 
-    Scenario:
-      Then I see the email sent banner
+    Scenario: Show the start annual review banner
+        And eurasia lawyers have annual review in "60" days
+        When the batch process has run
+        And I am viewing list item index for reference:SMOKE
+        Then I do not see a notification banner
+
+    Scenario: Show the email sent banner
+        And eurasia lawyers have annual review in "0" days
+        When the batch process has run
+        And I am viewing list item index for reference:SMOKE
+        Then I see the email sent banner

--- a/cypress/e2e/annual-review/banner-today.feature
+++ b/cypress/e2e/annual-review/banner-today.feature
@@ -3,9 +3,9 @@ Feature: Annual review banners
   Background:
     Given I am logged in as a "User"
     And A "lawyers" list exists for Eurasia
-    And eurasia lawyers are due to begin annual review
+    And eurasia lawyers have annual review today
     When the batch process has run
     And I am viewing list item index for reference:SMOKE
 
     Scenario:
-      Then I see the start banner
+      Then I see the email sent banner

--- a/cypress/e2e/annual-review/banners.feature
+++ b/cypress/e2e/annual-review/banners.feature
@@ -9,7 +9,4 @@ Feature: Annual review banners
 
     Scenario:
       Then I see the start banner
-
-
-
-
+      Then I see the notification text "Annual review will start on"

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,7 +12,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-const { logger } = require("webpack-cli/lib/utils");
+
 const { PrismaClient } = require("@prisma/client");
 const db = new PrismaClient();
 const cucumber = require("cypress-cucumber-preprocessor").default;
@@ -42,7 +42,7 @@ module.exports = (on, config) => {
       return result;
     },
     log: (message) => {
-      logger.log(message);
+      console.log(message);
       return null;
     },
     batch: async function () {

--- a/cypress/support/step_definitions/annual-review/scheduler/eurasia_lawyers_have_annual_review_today.js
+++ b/cypress/support/step_definitions/annual-review/scheduler/eurasia_lawyers_have_annual_review_today.js
@@ -1,0 +1,117 @@
+import { randCompanyName, randEmail, randFullName } from "@ngneat/falso";
+
+const today = new Date();
+
+Given("eurasia lawyers have annual review today", async () => {
+  await updateListForAnnualReview();
+  await createListItem("test-user");
+});
+
+async function updateListForAnnualReview() {
+  const todayAfternoon = new Date(today.getUTCFullYear(), today.getUTCMonth(), today.getDate(), 12, 0, 0);
+
+  await cy.task("db", {
+    operation: "list.update",
+    variables: {
+      where: {
+        reference: "SMOKE",
+      },
+      data: {
+        nextAnnualReviewStartDate: todayAfternoon, jsonData: {
+          users: ["smoke@cautionyourblast.com"],
+          currentAnnualReview: {
+            keyDates: {
+              unpublished: {
+                PROVIDER_FIVE_WEEKS: "2023-04-04T00:00:00.000Z",
+              },
+              annualReview: {
+                START: todayAfternoon.toISOString(),
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+async function createListItem(reference) {
+  const monthAfterToday = today;
+  monthAfterToday.setMonth(today.getMonth() + 1);
+
+  return await cy.task("db", {
+    operation: "listItem.create",
+    variables: {
+      data: {
+        reference,
+        ...createListItemBaseObject(),
+        history: {
+          createMany: {
+            data: [events.NEW(monthAfterToday)],
+          },
+        },
+        address: {
+          create: {
+            firstLine: "ref",
+            country: {
+              connect: {
+                name: "Eurasia",
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+const events = {
+  NEW: (date) => ({
+    time: date,
+    type: "ANNUAL_REVIEW_STARTED",
+    jsonData: {
+      eventName: "new",
+    },
+  }),
+};
+
+function createListItemBaseObject() {
+  return {
+    type: "lawyers",
+    isApproved: true,
+    isPublished: true,
+    isBlocked: false,
+    status: "PUBLISHED",
+    jsonData: createLawyersJsonData(),
+    list: {
+      connect: {
+        reference: "SMOKE",
+      },
+    },
+  };
+}
+
+function createLawyersJsonData() {
+  return {
+    country: "Eurasia",
+    contactName: randFullName(),
+    organisationName: randCompanyName(),
+    emailAddress: randEmail(),
+    speakEnglish: true,
+    websiteAddress: null,
+    regions: "France and UK",
+    phoneNumber: "1234567",
+    declaration: ["confirm"],
+    publishEmail: "Yes",
+    regulators: "Miniluv",
+    emergencyPhoneNumber: null,
+    representedBritishNationals: true,
+    metadata: {
+      emailVerified: true,
+    },
+    areasOfLaw: [],
+    size: "Independent lawyer / sole practitioner",
+    proBono: true,
+    legalAid: true,
+  };
+}

--- a/cypress/support/step_definitions/annual-review/scheduler/eurasia_lawyers_have_annual_review_today.js
+++ b/cypress/support/step_definitions/annual-review/scheduler/eurasia_lawyers_have_annual_review_today.js
@@ -2,13 +2,20 @@ import { randCompanyName, randEmail, randFullName } from "@ngneat/falso";
 
 const today = new Date();
 
-Given("eurasia lawyers have annual review today", async () => {
-  await updateListForAnnualReview();
+Given("eurasia lawyers have annual review in {string} days", async (days = "0") => {
+  await updateListForAnnualReview(days);
   await createListItem("test-user");
 });
 
-async function updateListForAnnualReview() {
-  const todayAfternoon = new Date(today.getUTCFullYear(), today.getUTCMonth(), today.getDate(), 12, 0, 0);
+async function updateListForAnnualReview(days) {
+  const todayAfternoon = new Date(
+    today.getUTCFullYear(),
+    today.getUTCMonth(),
+    today.getDate() + Number(days),
+    12,
+    0,
+    0
+  );
 
   await cy.task("db", {
     operation: "list.update",
@@ -17,7 +24,8 @@ async function updateListForAnnualReview() {
         reference: "SMOKE",
       },
       data: {
-        nextAnnualReviewStartDate: todayAfternoon, jsonData: {
+        nextAnnualReviewStartDate: todayAfternoon,
+        jsonData: {
           users: ["smoke@cautionyourblast.com"],
           currentAnnualReview: {
             keyDates: {

--- a/cypress/support/step_definitions/annual-review/scheduler/i_do_not_see_a_notification_banner.js
+++ b/cypress/support/step_definitions/annual-review/scheduler/i_do_not_see_a_notification_banner.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+And("I do not see a notification banner", () => {
+    cy.findByRole("region").should('not.contain', 'Annual review')
+  });

--- a/cypress/support/step_definitions/annual-review/scheduler/i_see_the_email_sent_banner.js
+++ b/cypress/support/step_definitions/annual-review/scheduler/i_see_the_email_sent_banner.js
@@ -1,0 +1,3 @@
+Then("I see the email sent banner", () => {
+  cy.findByText("All published service providers were sent a request to review their information on", { exact: false });
+});


### PR DESCRIPTION
# Description

The purpose of this PR is to add smoke tests to test the Annual Review banners are triggering correctly.

This PR is a combination of 3 Trello tickets:
- https://trello.com/c/QobnGDYX/1586-annual-review-smoke-tests-1-month-until-annual-review-banner
- https://trello.com/c/FrOILOGw/1583-annual-review-smoke-tests-annual-review-is-today
- https://trello.com/c/bbvxe1Ge/1584-annual-review-smoke-tests-annual-review-is-more-than-a-month-away