### PR TITLE
Validation fixes for unpublish action

### DIFF
--- a/src/scheduler/workers/unpublish/day/findNonRespondentsForList.ts
+++ b/src/scheduler/workers/unpublish/day/findNonRespondentsForList.ts
@@ -13,7 +13,9 @@ export async function findNonRespondentsForList(list: List) {
   const annualReviewDate = new Date(list.nextAnnualReviewStartDate!).toISOString();
 
   const editedSinceAnnualReviewDate: Prisma.EventWhereInput = {
-    type: "EDITED",
+    type: {
+      in: ["EDITED", "CHECK_ANNUAL_REVIEW"],
+    },
     time: {
       gte: annualReviewDate,
     },

--- a/src/scheduler/workers/unpublish/day/sendEmails.ts
+++ b/src/scheduler/workers/unpublish/day/sendEmails.ts
@@ -23,7 +23,7 @@ export async function main(list: ListWithCountryName) {
 
   const listItems = await findNonRespondentsForList(list);
 
-  if (!listItems) {
+  if (!listItems.length) {
     return;
   }
 


### PR DESCRIPTION
The following fixes are included:

- List items in CHECK_ANNUAL_REVIEW status are now excluded from the results when finding list items that have not been responded to in the unpublish event scheduler
- The unpublish event scheduler now correctly returns if there are no list items that have not been actioned