### PR TITLE
Feat/1572 auto pupulate date

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,6 +8,7 @@ module.exports = {
         alias: {
           "client/*": ["client/*"],
           "server/*": ["server/*"],
+          "scheduler/*": ["scheduler/*"],
         },
         extensions: [".ts", ".tsx"],
       },

--- a/cypress/e2e/annual-review/batch.feature
+++ b/cypress/e2e/annual-review/batch.feature
@@ -12,10 +12,18 @@ Feature: Eligible list items are calculated correctly
   I should only review providers that have been published for over a month,
   So that I do not have to verify details that have been recently reviewed.
 
-  Scenario:
+  Background:
     Given A "lawyers" list exists for Eurasia
-    And eurasia lawyers are due to begin annual review
-    When the batch process has run
+
+  Scenario:
+    When eurasia lawyers are due to begin annual review
+    And the batch process has run
     Then eligible list items are correct
 
-
+  Scenario: A date is added automatically if one is not set
+    When there are these list items
+      | contactName | status    | isPublished | isBlocked | isApproved | emailVerified | isPinned |
+      | Winston     | PUBLISHED | true        | false     | false      | true          | false    |
+    And no annual review date is set
+    And the batch process has run
+    Then an annual review date has been set

--- a/cypress/support/step_definitions/annual-review/scheduler/an_annual_review_date_has_been_set.js
+++ b/cypress/support/step_definitions/annual-review/scheduler/an_annual_review_date_has_been_set.js
@@ -1,4 +1,4 @@
-And("an annual review date has been set", async () => {
+Then("an annual review date has been set", async () => {
   cy.task("db", {
     operation: "list.findFirst",
     variables: {

--- a/cypress/support/step_definitions/annual-review/scheduler/an_annual_review_date_has_been_set.js
+++ b/cypress/support/step_definitions/annual-review/scheduler/an_annual_review_date_has_been_set.js
@@ -1,0 +1,12 @@
+And("an annual review date has been set", async () => {
+  cy.task("db", {
+    operation: "list.findFirst",
+    variables: {
+      where: {
+        reference: "SMOKE",
+      },
+    },
+  }).then((list) => {
+    cy.expect(list.nextAnnualReviewStartDate).not.to.equal(null);
+  });
+});

--- a/cypress/support/step_definitions/annual-review/scheduler/no_annual_review_date_is_set.js
+++ b/cypress/support/step_definitions/annual-review/scheduler/no_annual_review_date_is_set.js
@@ -1,0 +1,12 @@
+And("no annual review date is set", async () => {
+  cy.task("db", {
+    operation: "list.findFirst",
+    variables: {
+      where: {
+        reference: "SMOKE",
+      },
+    },
+  }).then((list) => {
+    cy.expect(list.nextAnnualReviewStartDate).to.equal(null);
+  });
+});

--- a/cypress/support/step_definitions/annual-review/the_list_is_in_annual_review.js
+++ b/cypress/support/step_definitions/annual-review/the_list_is_in_annual_review.js
@@ -26,6 +26,7 @@ Given("the list is in annual review", () => {
               reference: "ANNUAL_REVIEW_REF",
             },
           },
+          nextAnnualReviewStartDate: new Date()
         },
       },
     });

--- a/cypress/support/step_definitions/dashboard/there_is_a_list_with_all_states.js
+++ b/cypress/support/step_definitions/dashboard/there_is_a_list_with_all_states.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { rand, randCompanyName, randEmail, randFullName } from "@ngneat/falso";
+import { randCompanyName, randEmail, randFullName } from "@ngneat/falso";
 import { ListItemEvent } from "@prisma/client";
 
 Given("A {string} list exists for Eurasia", (providerType) => {

--- a/cypress/support/step_definitions/dashboard/there_is_a_list_with_all_states.js
+++ b/cypress/support/step_definitions/dashboard/there_is_a_list_with_all_states.js
@@ -42,7 +42,7 @@ function createListForService(service) {
       create: {
         type: service,
         reference: "SMOKE",
-        nextAnnualReviewStartDate: new Date(),
+        nextAnnualReviewStartDate: null,
         jsonData,
         country: {
           connect: {
@@ -53,7 +53,7 @@ function createListForService(service) {
       update: {
         type: service,
         jsonData,
-        nextAnnualReviewStartDate: new Date(),
+        nextAnnualReviewStartDate: null,
         items: {
           deleteMany: {},
         },
@@ -108,7 +108,7 @@ function setupPublishEvents(options) {
 
   const publishEvent = {
     type: ListItemEvent.PUBLISHED,
-    time: new Date("2022-01-01"),
+    time: new Date(),
     jsonData: {
       eventName: "publish",
       userId: "smoke",

--- a/src/scheduler/batch/main.ts
+++ b/src/scheduler/batch/main.ts
@@ -5,7 +5,7 @@ import { findListItems } from "server/models/listItem";
 import * as helpers from "./helpers";
 import { getCurrentAnnualReviewData, schedulerMilestoneDays } from "./helpers";
 import { ListItemWithHistory } from "server/components/dashboard/listsItems/types";
-import { addDays, startOfDay } from "date-fns";
+import { subDays, startOfDay } from "date-fns";
 import _ from "lodash";
 
 export async function populateCurrentAnnualReview(lists: List[]): Promise<void> {
@@ -62,9 +62,9 @@ export async function populateCurrentAnnualReview(lists: List[]): Promise<void> 
 }
 
 export async function updateListsForAnnualReview(today: Date): Promise<void> {
-  const annualReviewStartDate = addDays(today, schedulerMilestoneDays.post.ONE_MONTH);
+  const annualReviewStartDate = subDays(today, schedulerMilestoneDays.post.ONE_MONTH);
   if (annualReviewStartDate) {
-    const { result: lists } = await findListByAnnualReviewDate(annualReviewStartDate);
+    const { result: lists } = await findListByAnnualReviewDate(annualReviewStartDate, today);
 
     logger.info(
       `Found the lists ${lists?.map((list) => list.id)} matching annual review start date [${annualReviewStartDate}]`

--- a/src/scheduler/batch/main.ts
+++ b/src/scheduler/batch/main.ts
@@ -1,13 +1,12 @@
 import { findListByAnnualReviewDate, updateListForAnnualReview } from "server/models/list";
 import { findListsWithoutNextAnnualReview, addAnnualReviewToList } from "scheduler/batch/model";
-import type { ListWithFirstPublishedDate } from "scheduler/batch/model";
 import type { List, BaseListItemGetObject as ListItem } from "server/models/types";
 import { logger } from "scheduler/logger";
 import { findListItems } from "server/models/listItem";
 import * as helpers from "./helpers";
 import { getCurrentAnnualReviewData, schedulerMilestoneDays } from "./helpers";
 import type { ListItemWithHistory } from "server/components/dashboard/listsItems/types";
-import { addDays, startOfDay, addYears, isFuture } from "date-fns";
+import { addDays, startOfDay, addYears } from "date-fns";
 import _ from "lodash";
 
 export async function populateCurrentAnnualReview(lists: List[]): Promise<void> {

--- a/src/scheduler/batch/main.ts
+++ b/src/scheduler/batch/main.ts
@@ -1,18 +1,17 @@
+import { findListByAnnualReviewDate, updateListForAnnualReview } from "server/models/list";
 import {
-  findListByAnnualReviewDate,
-  updateListForAnnualReview,
-  findListsWithoutNextAnnualReview,
   findFirstPublishedDateForList,
+  findListsWithoutNextAnnualReview,
   addAnnualReviewToList,
-} from "server/models/list";
-import type { ListWithFirstPublishedDate } from "server/models/list";
-import { List } from "server/models/types";
-import { logger } from "server/services/logger";
+} from "scheduler/batch/model";
+import type { ListWithFirstPublishedDate } from "scheduler/batch/model";
+import type { List } from "server/models/types";
+import { logger } from "scheduler/logger";
 import { findListItems } from "server/models/listItem";
 import * as helpers from "./helpers";
 import { getCurrentAnnualReviewData, schedulerMilestoneDays } from "./helpers";
-import { ListItemWithHistory } from "server/components/dashboard/listsItems/types";
-import { addDays, startOfDay, addYears, isAfter } from "date-fns";
+import type { ListItemWithHistory } from "server/components/dashboard/listsItems/types";
+import { addDays, startOfDay, addYears, isFuture } from "date-fns";
 import _ from "lodash";
 
 export async function populateCurrentAnnualReview(lists: List[]): Promise<void> {
@@ -77,7 +76,7 @@ async function addAnnualReviewDateToPublishedLists(listsWithoutCurrentAnnualRevi
           return null;
         }
         const oneYearAfterFirstPublishedDate = addYears(publishEventResult.time, 1);
-        const isAfterToday = isAfter(oneYearAfterFirstPublishedDate, new Date());
+        const isAfterToday = isFuture(oneYearAfterFirstPublishedDate);
         if (!isAfterToday) {
           logger.error(`List with id ${list.id} has an old first published date. Annual review will not be set.`);
           return null;

--- a/src/scheduler/batch/main.ts
+++ b/src/scheduler/batch/main.ts
@@ -5,7 +5,7 @@ import { findListItems } from "server/models/listItem";
 import * as helpers from "./helpers";
 import { getCurrentAnnualReviewData, schedulerMilestoneDays } from "./helpers";
 import { ListItemWithHistory } from "server/components/dashboard/listsItems/types";
-import { subDays, startOfDay } from "date-fns";
+import { addDays, startOfDay } from "date-fns";
 import _ from "lodash";
 
 export async function populateCurrentAnnualReview(lists: List[]): Promise<void> {
@@ -62,9 +62,9 @@ export async function populateCurrentAnnualReview(lists: List[]): Promise<void> 
 }
 
 export async function updateListsForAnnualReview(today: Date): Promise<void> {
-  const annualReviewStartDate = subDays(today, schedulerMilestoneDays.post.ONE_MONTH);
+  const annualReviewStartDate = addDays(today, schedulerMilestoneDays.post.ONE_MONTH);
   if (annualReviewStartDate) {
-    const { result: lists } = await findListByAnnualReviewDate(annualReviewStartDate, today);
+    const { result: lists } = await findListByAnnualReviewDate(annualReviewStartDate);
 
     logger.info(
       `Found the lists ${lists?.map((list) => list.id)} matching annual review start date [${annualReviewStartDate}]`

--- a/src/scheduler/batch/main.ts
+++ b/src/scheduler/batch/main.ts
@@ -5,7 +5,7 @@ import {
   findFirstPublishedDateForList,
   addAnnualReviewToList,
 } from "server/models/list";
-import type {ListWithFirstPublishedDate} from "server/models/list";
+import type { ListWithFirstPublishedDate } from "server/models/list";
 import { List } from "server/models/types";
 import { logger } from "server/services/logger";
 import { findListItems } from "server/models/listItem";
@@ -68,18 +68,21 @@ export async function populateCurrentAnnualReview(lists: List[]): Promise<void> 
   }
 }
 
-async function addAnnualReviewDateToPublishedLists() {
+async function addAnnualReviewDateToPublishedLists(listsWithoutCurrentAnnualReviewDate: List[]) {
   try {
-    const listsWithoutCurrentAnnualReviewDate = await findListsWithoutNextAnnualReview();
     const listsWithPublishedListItem = await Promise.all(
-      (listsWithoutCurrentAnnualReviewDate as List[]).map(async (list) => {
+      listsWithoutCurrentAnnualReviewDate.map(async (list) => {
         const publishEventResult = await findFirstPublishedDateForList(list.id);
         if (!publishEventResult) {
           return null;
         }
         const oneYearAfterFirstPublishedDate = addYears(publishEventResult.time, 1);
         const isAfterToday = isAfter(oneYearAfterFirstPublishedDate, new Date());
-        return isAfterToday ? { listId: list.id, oneYearAfterFirstPublishedDate } : null;
+        if (!isAfterToday) {
+          logger.error(`List with id ${list.id} has an old first published date. Annual review will not be set.`);
+          return null;
+        }
+        return { listId: list.id, oneYearAfterFirstPublishedDate };
       })
     ).then((arr) => arr.filter(Boolean));
 
@@ -99,17 +102,22 @@ export async function updateListsForAnnualReview(today: Date): Promise<void> {
   const annualReviewStartDate = addDays(today, schedulerMilestoneDays.post.ONE_MONTH);
   if (annualReviewStartDate) {
     const { result: lists } = await findListByAnnualReviewDate(annualReviewStartDate);
+    const listsWithoutCurrentAnnualReviewDate = await findListsWithoutNextAnnualReview();
 
     logger.info(
       `Found the lists ${lists?.map((list) => list.id)} matching annual review start date [${annualReviewStartDate}]`
     );
+
+    if ((listsWithoutCurrentAnnualReviewDate as List[]).length) {
+      await addAnnualReviewDateToPublishedLists(listsWithoutCurrentAnnualReviewDate as List[]);
+    }
+
     if (!lists?.length) {
+      logger.error("updateListsForAnnualReview: no list with annual review found");
       return;
     }
     await populateCurrentAnnualReview(lists);
   }
-
-  await addAnnualReviewDateToPublishedLists();
 }
 
 /**

--- a/src/scheduler/batch/model.ts
+++ b/src/scheduler/batch/model.ts
@@ -1,0 +1,54 @@
+import { PrismaClient } from "@prisma/client";
+import { logger } from "scheduler/logger";
+import type { List } from "server/models/types";
+
+export const prisma = new PrismaClient();
+
+export interface ListWithFirstPublishedDate {
+  listId: number;
+  oneYearAfterFirstPublishedDate: Date;
+}
+
+export async function findFirstPublishedDateForList(listId: number) {
+  return await prisma.event.findFirst({
+    where: {
+      listItem: {
+        listId,
+      },
+      type: "PUBLISHED",
+    },
+    orderBy: {
+      time: "asc",
+    },
+  });
+}
+
+export async function addAnnualReviewToList({ listId, oneYearAfterFirstPublishedDate }: ListWithFirstPublishedDate) {
+  return await prisma.list.update({
+    where: {
+      id: listId,
+    },
+    data: {
+      nextAnnualReviewStartDate: oneYearAfterFirstPublishedDate,
+    },
+  });
+}
+
+export async function findListsWithoutNextAnnualReview() {
+  try {
+    const result = (await prisma.list.findMany({
+      where: {
+        nextAnnualReviewStartDate: null,
+      },
+      include: {
+        country: true,
+      },
+    })) as List[];
+
+    logger.debug(`${result.length} lists without nextAnnualReview found`);
+    return result;
+  } catch (error) {
+    logger.error(`findListsWithoutNextAnnualReview Error: ${(error as Error).message}`);
+    return { error: new Error("Unable to get lists in annual review") };
+  }
+}

--- a/src/scheduler/batch/model.ts
+++ b/src/scheduler/batch/model.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import { logger } from "scheduler/logger";
-import { addYears } from "date-fns";
+import { subYears } from "date-fns";
 
 export const prisma = new PrismaClient();
 
@@ -33,7 +33,7 @@ export async function findListsWithoutNextAnnualReview() {
               some: {
                 type: "PUBLISHED",
                 time: {
-                  gt: addYears(new Date(), -1).toISOString(),
+                  gt: subYears(new Date(), 1),
                 },
               },
             },

--- a/src/server/models/list.ts
+++ b/src/server/models/list.ts
@@ -90,7 +90,6 @@ export async function findListsWithCurrentAnnualReview(): Promise<Result<List[]>
   try {
     const result = (await prisma.list.findMany({
       where: {
-        nextAnnualReviewStartDate: null,
         jsonData: {
           path: ["currentAnnualReview", "eligibleListItems"],
           not: "",

--- a/src/server/models/list.ts
+++ b/src/server/models/list.ts
@@ -4,7 +4,7 @@ import { isGovUKEmailAddress } from "server/utils/validation";
 import { prisma } from "./db/prisma-client";
 
 import { CountryName, CurrentAnnualReview, List, ListCreateInput, ListUpdateInput, ServiceType } from "./types";
-import { subMonths, addYears, isBefore } from "date-fns";
+import { subMonths } from "date-fns";
 
 export async function findListById(listId: string | number): Promise<List | undefined> {
   try {

--- a/src/server/models/list.ts
+++ b/src/server/models/list.ts
@@ -4,7 +4,6 @@ import { isGovUKEmailAddress } from "server/utils/validation";
 import { prisma } from "./db/prisma-client";
 
 import { CountryName, CurrentAnnualReview, List, ListCreateInput, ListUpdateInput, ServiceType } from "./types";
-import { subMonths } from "date-fns";
 
 export async function findListById(listId: string | number): Promise<List | undefined> {
   try {
@@ -43,14 +42,15 @@ export async function findListByCountryAndType(country: CountryName, type: Servi
   }
 }
 
-export async function findListByAnnualReviewDate(annualReviewStartDate: Date): Promise<Result<List[]>> {
+export async function findListByAnnualReviewDate(annualReviewStartDate: Date, today: Date): Promise<Result<List[]>> {
   try {
     logger.debug(`searching for lists matching date [${annualReviewStartDate}]`);
 
     const result = (await prisma.list.findMany({
       where: {
         nextAnnualReviewStartDate: {
-          lte: annualReviewStartDate,
+          gte: annualReviewStartDate,
+          lt: today,
         },
       },
       include: {
@@ -61,7 +61,8 @@ export async function findListByAnnualReviewDate(annualReviewStartDate: Date): P
               some: {
                 type: "PUBLISHED",
                 time: {
-                  lte: subMonths(Date.now(), 1),
+                  gte: annualReviewStartDate,
+                  lte: today,
                 },
               },
             },


### PR DESCRIPTION
# Description

The purpose of this PR is to automatically populate a list with an annual review date if it needs one. This is all done in the batch process so the date won't appear instantly.

Link to Trello ticket: https://trello.com/c/34ehPuQr/1572-auto-populate-the-annual-review-start-date-on-lists