### PR TITLE
chore: make feedback link updates to start pages

### DIFF
--- a/docker/apply/Dockerfile
+++ b/docker/apply/Dockerfile
@@ -22,5 +22,5 @@ ENV PORT=3001
 ENV SERVICE_URL="apply:${PORT}"
 ENV SANDBOX="false"
 ENV LOG_PRETTY_PRINT="false"
-ENV FEEDBACK_LINK="mailto:digitalservicesfeedback@fco.gov.uk"
+ENV FEEDBACK_LINK="https://www.smartsurvey.co.uk/s/Apply-to-Find-a-Professional/"
 CMD [ "yarn", "runner", "start"]

--- a/docker/apply/forms-json/funeral-directors.json
+++ b/docker/apply/forms-json/funeral-directors.json
@@ -16,7 +16,7 @@
           "name": "QLkbfP",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">We welcome your <a class=\"govuk-link\" href=\"https://www.smartsurvey.co.uk/s/Find-a-Professional/\" target=\"_blank\">feedback</a> to help us improve this service</p>",
+          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">We welcome your <a class=\"govuk-link\" href=\"https://www.smartsurvey.co.uk/s/Apply-to-Find-a-Professional/\" target=\"_blank\">feedback</a> to help us improve this service</p>",
           "schema": {}
         }
       ],

--- a/docker/apply/forms-json/funeral-directors.json
+++ b/docker/apply/forms-json/funeral-directors.json
@@ -16,7 +16,7 @@
           "name": "QLkbfP",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">If you have feedback specifically about this digital service, the FCDO welcomes your views.</p>\n\n<p class=\"govuk-body\">Email: <a href=\"mailto:digitalservicesfeedback@fco.gov.uk\" class=\"govuk-link\">digitalservicesfeedback@fco.gov.uk</a></p>",
+          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">We welcome your <a class=\"govuk-link\" href=\"https://www.smartsurvey.co.uk/s/Find-a-Professional/\" target=\"_blank\">feedback</a> to help us improve this service</p>",
           "schema": {}
         }
       ],
@@ -1687,7 +1687,9 @@
       "title": "Company details"
     }
   ],
-  "phaseBanner": {},
+  "phaseBanner": {
+    "phase": "beta"
+  },
   "metadata": {
     "type": "funeralDirectors"
   },
@@ -1703,6 +1705,10 @@
     }
   ],
   "version": 2,
+  "feedback": {
+    "feedbackForm": false,
+    "url": "/smart-survey"
+  },
   "conditions": [
     {
       "name": "oV9fvQl39FkGahoM46257",

--- a/docker/apply/forms-json/funeral-directors.json
+++ b/docker/apply/forms-json/funeral-directors.json
@@ -1705,10 +1705,6 @@
     }
   ],
   "version": 2,
-  "feedback": {
-    "feedbackForm": false,
-    "url": "/smart-survey"
-  },
   "conditions": [
     {
       "name": "oV9fvQl39FkGahoM46257",

--- a/docker/apply/forms-json/lawyers.json
+++ b/docker/apply/forms-json/lawyers.json
@@ -16,7 +16,7 @@
           "name": "QLkbfP",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">We welcome your <a class=\"govuk-link\" href=\"https://www.smartsurvey.co.uk/s/Find-a-Professional/\" target=\"_blank\">feedback</a> to help us improve this service</p>",
+          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">We welcome your <a class=\"govuk-link\" href=\"https://www.smartsurvey.co.uk/s/Apply-to-Find-a-Professional/\" target=\"_blank\">feedback</a> to help us improve this service</p>",
           "schema": {}
         }
       ],

--- a/docker/apply/forms-json/lawyers.json
+++ b/docker/apply/forms-json/lawyers.json
@@ -1628,10 +1628,6 @@
     }
   ],
   "version": 2,
-  "feedback": {
-    "feedbackForm": false,
-    "url": "/smart-survey"
-  },
   "conditions": [
     {
       "name": "oV9fvQl39FkGahoM46257",

--- a/docker/apply/forms-json/lawyers.json
+++ b/docker/apply/forms-json/lawyers.json
@@ -16,7 +16,7 @@
           "name": "QLkbfP",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">If you have feedback specifically about this digital service, the FCDO welcomes your views.</p>\n\n<p class=\"govuk-body\">Email: <a href=\"mailto:digitalservicesfeedback@fco.gov.uk\" class=\"govuk-link\">digitalservicesfeedback@fco.gov.uk</a></p>",
+          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">We welcome your <a class=\"govuk-link\" href=\"https://www.smartsurvey.co.uk/s/Find-a-Professional/\" target=\"_blank\">feedback</a> to help us improve this service</p>",
           "schema": {}
         }
       ],
@@ -1610,7 +1610,9 @@
       "title": "Company details"
     }
   ],
-  "phaseBanner": {},
+  "phaseBanner": {
+    "phase": "beta"
+  },
   "metadata": {
     "type": "lawyers"
   },
@@ -1621,11 +1623,15 @@
       "title": "Post to lists",
       "type": "webhook",
       "outputConfiguration": {
-        "url": "http://lists:3000/ingest/lawyers"
+        "url": "http://list:3000/ingest/lawyers"
       }
     }
   ],
   "version": 2,
+  "feedback": {
+    "feedbackForm": false,
+    "url": "/smart-survey"
+  },
   "conditions": [
     {
       "name": "oV9fvQl39FkGahoM46257",

--- a/docker/apply/forms-json/lawyers.json
+++ b/docker/apply/forms-json/lawyers.json
@@ -1623,7 +1623,7 @@
       "title": "Post to lists",
       "type": "webhook",
       "outputConfiguration": {
-        "url": "http://list:3000/ingest/lawyers"
+        "url": "http://lists:3000/ingest/lawyers"
       }
     }
   ],

--- a/docker/apply/forms-json/translators-interpreters.json
+++ b/docker/apply/forms-json/translators-interpreters.json
@@ -2764,10 +2764,6 @@
     }
   ],
   "version": 2,
-  "feedback": {
-    "feedbackForm": false,
-    "url": "/smart-survey"
-  },
   "conditions": [
     {
       "name": "50_TW9NLlvr2820-1-Qt6",

--- a/docker/apply/forms-json/translators-interpreters.json
+++ b/docker/apply/forms-json/translators-interpreters.json
@@ -16,7 +16,7 @@
           "name": "QLkbfP",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">We welcome your <a class=\"govuk-link\" href=\"https://www.smartsurvey.co.uk/s/Find-a-Professional/\" target=\"_blank\">feedback</a> to help us improve this service</p>",
+          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">We welcome your <a class=\"govuk-link\" href=\"https://www.smartsurvey.co.uk/s/Apply-to-Find-a-Professional/\" target=\"_blank\">feedback</a> to help us improve this service</p>",
           "schema": {}
         }
       ],

--- a/docker/apply/forms-json/translators-interpreters.json
+++ b/docker/apply/forms-json/translators-interpreters.json
@@ -16,7 +16,7 @@
           "name": "QLkbfP",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">If you have feedback specifically about this digital service, the FCDO welcomes your views.</p>\n\n<p class=\"govuk-body\">Email: <a href=\"mailto:digitalservicesfeedback@fco.gov.uk\" class=\"govuk-link\">digitalservicesfeedback@fco.gov.uk</a></p>",
+          "content": "<p class=\"govuk-body govuk-!-font-weight-bold\">Feedback on this service</p>\n<p class=\"govuk-body\">We welcome your <a class=\"govuk-link\" href=\"https://www.smartsurvey.co.uk/s/Find-a-Professional/\" target=\"_blank\">feedback</a> to help us improve this service</p>",
           "schema": {}
         }
       ],
@@ -2746,7 +2746,9 @@
     }
   ],
   "sections": [],
-  "phaseBanner": {},
+  "phaseBanner": {
+    "phase": "beta"
+  },
   "metadata": {
     "type": "translators-interpreters"
   },
@@ -2762,6 +2764,10 @@
     }
   ],
   "version": 2,
+  "feedback": {
+    "feedbackForm": false,
+    "url": "/smart-survey"
+  },
   "conditions": [
     {
       "name": "50_TW9NLlvr2820-1-Qt6",

--- a/src/server/components/development/router.ts
+++ b/src/server/components/development/router.ts
@@ -7,9 +7,6 @@ import { isLocalHost } from "server/config";
 
 export const developmentRouter = express.Router();
 
-developmentRouter.get(`/smart-survey`, (_req, res) => {
-  res.status(301).redirect("https://www.smartsurvey.co.uk/s/Apply-to-Find-a-Professional/");
-});
 developmentRouter.get(`/development*`, ensureAuthenticated);
 
 // deploy db to apply future database migration changes

--- a/src/server/components/development/router.ts
+++ b/src/server/components/development/router.ts
@@ -8,7 +8,7 @@ import { isLocalHost } from "server/config";
 export const developmentRouter = express.Router();
 
 developmentRouter.get(`/smart-survey`, (_req, res) => {
-  res.status(301).redirect("https://www.smartsurvey.co.uk/s/Apply-to-Find-a-Professional/");
+  res.status(301).redirect("https://www.smartsurvey.co.uk/s/Find-a-Professional/");
 });
 developmentRouter.get(`/development*`, ensureAuthenticated);
 

--- a/src/server/components/development/router.ts
+++ b/src/server/components/development/router.ts
@@ -8,7 +8,7 @@ import { isLocalHost } from "server/config";
 export const developmentRouter = express.Router();
 
 developmentRouter.get(`/smart-survey`, (_req, res) => {
-  res.status(301).redirect("https://www.smartsurvey.co.uk/s/Find-a-Professional/");
+  res.status(301).redirect("https://www.smartsurvey.co.uk/s/Apply-to-Find-a-Professional/");
 });
 developmentRouter.get(`/development*`, ensureAuthenticated);
 

--- a/src/server/components/development/router.ts
+++ b/src/server/components/development/router.ts
@@ -7,6 +7,9 @@ import { isLocalHost } from "server/config";
 
 export const developmentRouter = express.Router();
 
+developmentRouter.get(`/smart-survey`, (_req, res) => {
+  res.status(301).redirect("https://www.smartsurvey.co.uk/s/Apply-to-Find-a-Professional/");
+});
 developmentRouter.get(`/development*`, ensureAuthenticated);
 
 // deploy db to apply future database migration changes

--- a/src/server/views/includes/phase-banner.njk
+++ b/src/server/views/includes/phase-banner.njk
@@ -4,5 +4,5 @@
     tag: {
       text: "beta"
     },
-    html: 'This is a new service – your <a class="govuk-link" href="mailto:digitalservicesfeedback@fco.gov.uk">feedback</a> will help us to improve it.'
+    html: 'This is a new service – your <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/Find-a-Professional/">feedback</a> will help us to improve it.'
 }) }}

--- a/src/server/views/lists/partials/funeral-directors/funeral-directors-notice.njk
+++ b/src/server/views/lists/partials/funeral-directors/funeral-directors-notice.njk
@@ -25,13 +25,12 @@
 {% include 'includes/disclaimer.njk' %}
 <h2 class="govuk-heading-m" id="feedback-heading">Feedback on service providers</h2>
 <p class="govuk-body">
-  If you have feedback on any funeral directors, contact the <a class="govuk-link" href="https://www.gov.uk/world/embassies" class="govuk-link" target="_blank">British embassy or consulate</a> in
+  If you have feedback on any funeral directors, contact the <a class="govuk-link" href="https://www.gov.uk/world/embassies" target="_blank">British embassy or consulate</a> in
   the relevant country. Providers will be removed from the list where appropriate.
 </p>
 <h2 class="govuk-heading-m">Feedback on this service</h2>
 <p class="govuk-body">
-  If you have feedback specifically about this digital service, the FCDO welcomes your views. Email:
-  <a class="govuk-link" href="mailto:digitalservicesfeedback@fco.gov.uk" class="govuk-link" target="_blank">digitalservicesfeedback@fco.gov.uk</a>
+  We welcome your <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/Find-a-Professional/" target="_blank">feedback</a> to help us improve this service
 </p>
 <h2 class="govuk-heading-m">Apply to be added to this service</h2>
 <p class="govuk-body">

--- a/src/server/views/lists/partials/lawyers/lawyers-notice.njk
+++ b/src/server/views/lists/partials/lawyers/lawyers-notice.njk
@@ -31,13 +31,12 @@
 {% include 'includes/disclaimer.njk' %}
 <h2 class="govuk-heading-m" id="feedback-heading">Feedback on lawyers</h2>
 <p class="govuk-body">
-  If you have feedback on lawyers, contact the <a class="govuk-link" href="https://www.gov.uk/world/embassies" class="govuk-link" target="_blank">British embassy or consulate</a> in
+  If you have feedback on lawyers, contact the <a class="govuk-link" href="https://www.gov.uk/world/embassies" target="_blank">British embassy or consulate</a> in
   the relevant country. Providers will be removed from the list where appropriate.
 </p>
 <h2 class="govuk-heading-m">Feedback on this service</h2>
 <p class="govuk-body">
-  If you have feedback specifically about this digital service, the FCDO welcomes your views. Email:
-  <a class="govuk-link" href="mailto:digitalservicesfeedback@fco.gov.uk" class="govuk-link" target="_blank">digitalservicesfeedback@fco.gov.uk</a>
+  We welcome your <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/Find-a-Professional/" target="_blank">feedback</a> to help us improve this service
 </p>
 <h2 class="govuk-heading-m">Apply to be added to this service</h2>
 <p class="govuk-body">

--- a/src/server/views/lists/partials/translators-interpreters/translators-interpreters-notice.njk
+++ b/src/server/views/lists/partials/translators-interpreters/translators-interpreters-notice.njk
@@ -29,13 +29,12 @@
 {% include 'includes/disclaimer.njk' %}
 <h2 class="govuk-heading-m" id="feedback-heading">Feedback on service providers</h2>
 <p class="govuk-body">
-  If you have feedback on any translators or interpreters, contact the <a class="govuk-link" href="https://www.gov.uk/world/embassies" class="govuk-link" target="_blank">British embassy or consulate</a> in
+  If you have feedback on any translators or interpreters, contact the <a class="govuk-link" href="https://www.gov.uk/world/embassies" target="_blank">British embassy or consulate</a> in
   the relevant country. Providers will be removed from the list where appropriate.
 </p>
 <h2 class="govuk-heading-m">Feedback on this service</h2>
 <p class="govuk-body">
-  If you have feedback specifically about this digital service, the FCDO welcomes your views. Email:
-  <a class="govuk-link" href="mailto:digitalservicesfeedback@fco.gov.uk" class="govuk-link" target="_blank">digitalservicesfeedback@fco.gov.uk</a>
+  We welcome your <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/Find-a-Professional/" target="_blank">feedback</a> to help us improve this service
 </p>
 <h2 class="govuk-heading-m">Apply to be added to this service</h2>
 <p class="govuk-body">


### PR DESCRIPTION
# Description

The purpose of this ticket is to change the feedback links on all the apply journeys (apart form the covid one).

Link to Trello ticket: https://trello.com/c/2od9XQQr/1636-change-feedback-link-on-all-find-a-professional-journeys