### PR TITLE
Feat/1645 enable editing

### DIFF
--- a/src/server/components/auth/helpers.ts
+++ b/src/server/components/auth/helpers.ts
@@ -25,15 +25,6 @@ export function ensureUserIsAdministrator(req: Request, res: Response, next: Nex
   }
 }
 
-export function onlyAllowAdminsEditAnnualReviewDate(req: Request, res: Response, next: NextFunction) {
-  if(req.user?.isAdministrator) {
-    return next();
-  }
-
-  req.flash("error", "You do not have permissions to edit the annual review date");
-  return res.redirect(res?.locals.listsEditUrl);
-}
-
 export async function initAuth(server: Express): Promise<void> {
   await configureExpressSession(server);
   await configurePassport(server);

--- a/src/server/components/dashboard/controllers.ts
+++ b/src/server/components/dashboard/controllers.ts
@@ -208,7 +208,6 @@ export async function listsEditController(req: Request, res: Response, next: Nex
         return next();
       }
     }
-    const userExistsInListJson = list?.jsonData.users?.includes(req.user!.userData.email);
 
     res.render(templateUrl, {
       ...DEFAULT_VIEW_PROPS,
@@ -216,7 +215,6 @@ export async function listsEditController(req: Request, res: Response, next: Nex
       lastAnnualReviewStartDate,
       listId,
       user: req.user?.userData,
-      userExistsInListJson,
       list,
       req,
       csrfToken: getCSRFToken(req),

--- a/src/server/components/dashboard/controllers.ts
+++ b/src/server/components/dashboard/controllers.ts
@@ -208,6 +208,7 @@ export async function listsEditController(req: Request, res: Response, next: Nex
         return next();
       }
     }
+    const userExistsInListJson = list?.jsonData.users?.includes(req.user!.userData.email);
 
     res.render(templateUrl, {
       ...DEFAULT_VIEW_PROPS,
@@ -215,6 +216,7 @@ export async function listsEditController(req: Request, res: Response, next: Nex
       lastAnnualReviewStartDate,
       listId,
       user: req.user?.userData,
+      userExistsInListJson,
       list,
       req,
       csrfToken: getCSRFToken(req),

--- a/src/server/components/dashboard/listsItems/itemsRouter.ts
+++ b/src/server/components/dashboard/listsItems/itemsRouter.ts
@@ -18,7 +18,6 @@ import { findListItemById } from "server/models/listItem";
 import { HttpException } from "server/middlewares/error-handlers";
 import { updateRouter } from "./item/update/updateRouter";
 import { validateAccessToList } from "server/components/dashboard/listsItems/validateAccessToList";
-import { onlyAllowAdminsEditAnnualReviewDate } from "server/components/auth/helpers";
 
 export const listRouter = express.Router();
 
@@ -96,5 +95,5 @@ listRouter.use("/:listId/items/:listItemId", updateRouter);
 
 listRouter.post("/:listId/publisher-delete", controllers.listPublisherDelete);
 
-listRouter.get("/:listId/annual-review-date", onlyAllowAdminsEditAnnualReviewDate, annualReview.editDateGetController);
-listRouter.post("/:listId/annual-review-date", onlyAllowAdminsEditAnnualReviewDate, annualReview.editDatePostController);
+listRouter.get("/:listId/annual-review-date", annualReview.editDateGetController);
+listRouter.post("/:listId/annual-review-date", annualReview.editDatePostController);

--- a/src/server/views/dashboard/lists-edit.njk
+++ b/src/server/views/dashboard/lists-edit.njk
@@ -41,7 +41,7 @@
             <dd class="govuk-summary-list__value" data-testid="annual-review-date">
               {{ annualReviewStartDate }}
             </dd>
-            {% if user.jsonData.roles.includes('Administrator') %}
+            {% if user.jsonData.roles.includes('Administrator') or userExistsInListJson %}
             <dd class="govuk-summary-list__actions">
               <a class="govuk-link" href="{{ dashboardRoutes.listsEditAnnualReviewDate.replace(':listId', list.id) }}">
                 Change<span class="govuk-visually-hidden"> date</span>

--- a/src/server/views/dashboard/lists-edit.njk
+++ b/src/server/views/dashboard/lists-edit.njk
@@ -41,13 +41,11 @@
             <dd class="govuk-summary-list__value" data-testid="annual-review-date">
               {{ annualReviewStartDate }}
             </dd>
-            {% if user.jsonData.roles.includes('Administrator') or userExistsInListJson %}
             <dd class="govuk-summary-list__actions">
               <a class="govuk-link" href="{{ dashboardRoutes.listsEditAnnualReviewDate.replace(':listId', list.id) }}">
                 Change<span class="govuk-visually-hidden"> date</span>
               </a>
             </dd>
-            {% endif %}
           </div>
         </dl>
       </div>


### PR DESCRIPTION
from #605 

Description

The purpose of this PR is to enable the ability to change annual review date for non admin users that belong to a list.

Link to ticket in Trello: https://trello.com/c/dtdXxy7o/1645-list-members-are-unable-to-set-or-change-annual-review-date