### PR TITLE
refactor(translators-interpreters.ts): for scenario where both interpreter and translator

### DIFF
--- a/src/server/components/lists/searches/translators-interpreters.ts
+++ b/src/server/components/lists/searches/translators-interpreters.ts
@@ -47,7 +47,9 @@ const serviceTypeToNoun: Record<string, string> = {
 
 function makeResultsTitle(country: string, servicesProvided: string[]): string {
   const sanitisedServicesProvidedQuery = servicesProvided.map((service) => serviceTypeToNoun[service]).filter(Boolean);
-  return `${sanitisedServicesProvidedQuery.join(" or ")} in ${country}`;
+  const formattedService =
+    sanitisedServicesProvidedQuery.length > 1 ? "Translators or interpreters" : sanitisedServicesProvidedQuery[0];
+  return `${formattedService} in ${country}`;
 }
 
 interface SwornOutputTypes {

--- a/src/server/components/lists/searches/translators-interpreters.ts
+++ b/src/server/components/lists/searches/translators-interpreters.ts
@@ -48,7 +48,7 @@ const serviceTypeToNoun: Record<string, string> = {
 function makeResultsTitle(country: string, servicesProvided: string[]): string {
   const sanitisedServicesProvidedQuery = servicesProvided.map((service) => serviceTypeToNoun[service]).filter(Boolean);
   const formattedService =
-    sanitisedServicesProvidedQuery.length > 1 ? "Translators or interpreters" : sanitisedServicesProvidedQuery[0];
+    sanitisedServicesProvidedQuery.length > 1 ? "Translators and interpreters" : sanitisedServicesProvidedQuery[0];
   return `${formattedService} in ${country}`;
 }
 

--- a/src/server/components/lists/searches/translators-interpreters.ts
+++ b/src/server/components/lists/searches/translators-interpreters.ts
@@ -41,15 +41,13 @@ export const translatorsInterpretersQuestionsSequence = [
 ];
 
 const serviceTypeToNoun: Record<string, string> = {
-  translation: "Translators",
-  interpretation: "Interpreters",
+  translation: "translators",
+  interpretation: "interpreters",
 };
 
 function makeResultsTitle(country: string, servicesProvided: string[]): string {
   const sanitisedServicesProvidedQuery = servicesProvided.map((service) => serviceTypeToNoun[service]).filter(Boolean);
-  const formattedService =
-    sanitisedServicesProvidedQuery.length > 1 ? "Translators and interpreters" : sanitisedServicesProvidedQuery[0];
-  return `${formattedService} in ${country}`;
+  return `${sanitisedServicesProvidedQuery.join(" and ")} in ${country}`;
 }
 
 interface SwornOutputTypes {

--- a/src/server/views/lists/partials/translators-interpreters/translators-interpreters-results-list.njk
+++ b/src/server/views/lists/partials/translators-interpreters/translators-interpreters-results-list.njk
@@ -11,7 +11,7 @@
 {% if searchResults.length === 0 %}
   <p class="govuk-body">We couldn’t find any results that match your search terms. Try changing these to search again.</p>
 {% else %}
-  <h2 class="govuk-heading-l govuk-!-margin-bottom-4">{{resultsTitle}}</h2>
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-4">{{_.upperFirst(resultsTitle)}}</h2>
 
   {% if hasSworn.interpreters or hasSworn.translators %}
     <div class="govuk-warning-text">


### PR DESCRIPTION
The purpose of this pull request is to update the `translators-interpreters.ts` file to improve the readability of the page title.

This commit changes the `formattedService` variable to use "interpreter" in lowercase and "and" instead of "or" when both an interpreter and a translator are present. This makes the page title more consistent, clear, and easier to read.