### PR TITLE
refactor(translators-interpreters.ts): refactor searchTranslatorsInte…

### DIFF
--- a/src/server/components/lists/searches/translators-interpreters.ts
+++ b/src/server/components/lists/searches/translators-interpreters.ts
@@ -185,10 +185,20 @@ export async function searchTranslatorsInterpreters(req: Request, res: Response)
     searchResults = await TranslatorInterpreterListItem.findPublishedTranslatorsInterpretersPerCountry(filterProps);
     searchResults = searchResults.map((listItem: TranslatorInterpreterListItemGetObject) => {
       if (listItem.jsonData.languagesProvided) {
-        listItem.jsonData.languagesProvided = listItem.jsonData.languagesProvided?.map((language: string) => {
-          return metaData.languages[language];
-        });
+        listItem.jsonData.languagesProvided = listItem.jsonData.languagesProvided?.map(
+          (language: string) => metaData.languages[language]
+        );
       }
+
+      if (listItem.jsonData.deliveryOfServices?.includes("inPerson")) {
+        listItem.jsonData = {
+          ...listItem.jsonData,
+          deliveryOfServices: listItem.jsonData.deliveryOfServices.map((service) =>
+            service === "inPerson" ? "In person" : service
+          ),
+        };
+      }
+
       return listItem;
     });
   }


### PR DESCRIPTION
# Description

The purpose of this PR is to change the displayed text for the translators page from "InPerson" to "In person".

This happens because "inPerson" is stored in the jsonData column of a listItem and this is rendered 
<img width="694" alt="Screenshot 2023-05-17 at 12 14 34" src="https://github.com/UKForeignOffice/lists/assets/1377253/aa2f0de8-993b-41d8-91fa-148c2c51596b">
