### PR TITLE
Fix/1823 feedback link

### DIFF
--- a/src/server/views/lists/partials/funeral-directors/funeral-directors-results-list.njk
+++ b/src/server/views/lists/partials/funeral-directors/funeral-directors-results-list.njk
@@ -28,7 +28,7 @@
   </div>
 
 {% if (print !== "yes") %}
-  <p class="govuk-body">Links to funeral director websites will open in a new tab. You can give <a class="govuk-link" href="/application/provider-contact/contact-us">feedback</a> on individual funeral directors or this service.</p>
+  <p class="govuk-body">Links to funeral director websites will open in a new tab. You can give <a class="govuk-link" href="/complain/provider-complaint/form">feedback</a> on individual funeral directors or this service.</p>
 {% endif %}
 {% if (print === "yes") %}
 {% include 'includes/disclaimer.njk' %}

--- a/src/server/views/lists/partials/funeral-directors/funeral-directors-results-list.njk
+++ b/src/server/views/lists/partials/funeral-directors/funeral-directors-results-list.njk
@@ -27,12 +27,16 @@
     </strong>
   </div>
 
-{% if (print !== "yes") %}
-  <p class="govuk-body">Links to funeral director websites will open in a new tab. You can give <a class="govuk-link" href="/complain/provider-complaint/form">feedback</a> on individual funeral directors or this service.</p>
-{% endif %}
-{% if (print === "yes") %}
-{% include 'includes/disclaimer.njk' %}
-{% endif %}
+  <p class="govuk-body noprint">
+    Links to funeral director websites will open in a new tab. You can give
+    <a class="govuk-link" href="/complain/provider-complaint/form">feedback</a>
+    on individual funeral directors or this service.
+  </p>
+
+  {% if (print === "yes") %}
+    {% include 'includes/disclaimer.njk' %}
+  {% endif %}
+
   <p class="govuk-body">
     Results are ordered
     {% if regionIsSet %}

--- a/src/server/views/lists/partials/funeral-directors/funeral-directors-results-list.njk
+++ b/src/server/views/lists/partials/funeral-directors/funeral-directors-results-list.njk
@@ -27,16 +27,12 @@
     </strong>
   </div>
 
-  <p class="govuk-body noprint">
-    Links to funeral director websites will open in a new tab. You can give
-    <a class="govuk-link" href="/find/funeral-directors#feedback-heading">feedback</a>
-    on individual funeral directors or this service.
-  </p>
-
-  {% if (print === "yes") %}
-    {% include 'includes/disclaimer.njk' %}
-  {% endif %}
-
+{% if (print !== "yes") %}
+  <p class="govuk-body">Links to funeral director websites will open in a new tab. You can give <a class="govuk-link" href="/application/provider-contact/contact-us">feedback</a> on individual funeral directors or this service.</p>
+{% endif %}
+{% if (print === "yes") %}
+{% include 'includes/disclaimer.njk' %}
+{% endif %}
   <p class="govuk-body">
     Results are ordered
     {% if regionIsSet %}

--- a/src/server/views/lists/partials/lawyers/lawyers-results-list.njk
+++ b/src/server/views/lists/partials/lawyers/lawyers-results-list.njk
@@ -18,11 +18,9 @@
     </strong>
   </div>
 
-  <p class="govuk-body noprint">
-    Links to lawyer websites will open in a new tab. You can give
-    <a class="govuk-link" href="/find/lawyers#feedback-heading">feedback</a>
-    on individual lawyers or this service.
-  </p>
+{% if (print !== "yes") %}
+  <p class="govuk-body">Links to lawyer websites will open in a new tab. You can give <a class="govuk-link" href="/application/provider-contact/contact-us">feedback</a> on individual lawyers or this service.</p>
+{% endif %}
 {% if (print === "yes") %}
 {% include 'includes/disclaimer.njk' %}
 {% endif %}

--- a/src/server/views/lists/partials/lawyers/lawyers-results-list.njk
+++ b/src/server/views/lists/partials/lawyers/lawyers-results-list.njk
@@ -19,7 +19,7 @@
   </div>
 
 {% if (print !== "yes") %}
-  <p class="govuk-body">Links to lawyer websites will open in a new tab. You can give <a class="govuk-link" href="/application/provider-contact/contact-us">feedback</a> on individual lawyers or this service.</p>
+  <p class="govuk-body">Links to lawyer websites will open in a new tab. You can give <a class="govuk-link" href="/complain/provider-complaint/form">feedback</a> on individual lawyers or this service.</p>
 {% endif %}
 {% if (print === "yes") %}
 {% include 'includes/disclaimer.njk' %}

--- a/src/server/views/lists/partials/lawyers/lawyers-results-list.njk
+++ b/src/server/views/lists/partials/lawyers/lawyers-results-list.njk
@@ -18,9 +18,11 @@
     </strong>
   </div>
 
-{% if (print !== "yes") %}
-  <p class="govuk-body">Links to lawyer websites will open in a new tab. You can give <a class="govuk-link" href="/complain/provider-complaint/form">feedback</a> on individual lawyers or this service.</p>
-{% endif %}
+  <p class="govuk-body noprint">
+    Links to lawyer websites will open in a new tab. You can give
+    <a class="govuk-link" href="/complain/provider-complaint/form">feedback</a>
+    on individual lawyers or this service.
+  </p>
 {% if (print === "yes") %}
 {% include 'includes/disclaimer.njk' %}
 {% endif %}

--- a/src/server/views/lists/partials/translators-interpreters/translators-interpreters-results-list.njk
+++ b/src/server/views/lists/partials/translators-interpreters/translators-interpreters-results-list.njk
@@ -39,7 +39,7 @@
   {% endif %}
 
 {% if (print !== "yes") %}
-  <p class="govuk-body">Links to translator and interpreter websites will open in a new tab. You can give <a class="govuk-link" href="/application/provider-contact/contact-us">feedback</a> on individual translators or interpreters.</p>
+  <p class="govuk-body">Links to translator and interpreter websites will open in a new tab. You can give <a class="govuk-link" href="/complain/provider-complaint/form">feedback</a> on individual translators or interpreters.</p>
 {% endif %}
 {% if (print === "yes") %}
 {% include 'includes/disclaimer.njk' %}

--- a/src/server/views/lists/partials/translators-interpreters/translators-interpreters-results-list.njk
+++ b/src/server/views/lists/partials/translators-interpreters/translators-interpreters-results-list.njk
@@ -38,9 +38,12 @@
     </div>
   {% endif %}
 
-{% if (print !== "yes") %}
-  <p class="govuk-body">Links to translator and interpreter websites will open in a new tab. You can give <a class="govuk-link" href="/complain/provider-complaint/form">feedback</a> on individual translators or interpreters.</p>
-{% endif %}
+  <p class="govuk-body noprint">
+    Links to translator and interpreter websites will open in a new tab. You can give
+    <a class="govuk-link" href="/complain/provider-complaint/form">feedback</a>
+    on individual translators or interpreters.
+  </p>
+
 {% if (print === "yes") %}
 {% include 'includes/disclaimer.njk' %}
 {% endif %}

--- a/src/server/views/lists/partials/translators-interpreters/translators-interpreters-results-list.njk
+++ b/src/server/views/lists/partials/translators-interpreters/translators-interpreters-results-list.njk
@@ -38,12 +38,9 @@
     </div>
   {% endif %}
 
-  <p class="govuk-body noprint">
-    Links to translator and interpreter websites will open in a new tab. You can give
-    <a class="govuk-link" href="/find/translators-interpreters#feedback-heading">feedback</a>
-    on individual translators or interpreters.
-  </p>
-
+{% if (print !== "yes") %}
+  <p class="govuk-body">Links to translator and interpreter websites will open in a new tab. You can give <a class="govuk-link" href="/application/provider-contact/contact-us">feedback</a> on individual translators or interpreters.</p>
+{% endif %}
 {% if (print === "yes") %}
 {% include 'includes/disclaimer.njk' %}
 {% endif %}


### PR DESCRIPTION
# Description

The purpose of this ticket is to update the feedback link on the find results page so it goes to the contact us page instead of the start page.
