### PR TITLE
fix: add address country to translators

### DIFF
--- a/docker/apply/forms-json/translators-interpreters.json
+++ b/docker/apply/forms-json/translators-interpreters.json
@@ -127,7 +127,7 @@
           "schema": {}
         },
         {
-          "name": "addressCountry",
+          "name": "country",
           "options": {},
           "type": "AutocompleteField",
           "title": "Country",

--- a/docker/apply/forms-json/translators-interpreters.json
+++ b/docker/apply/forms-json/translators-interpreters.json
@@ -127,6 +127,14 @@
           "schema": {}
         },
         {
+          "name": "addressCountry",
+          "options": {},
+          "type": "AutocompleteField",
+          "title": "Country",
+          "list": "country",
+          "schema": {}
+        },
+        {
           "name": "addressDisplay",
           "options": {},
           "type": "RadiosField",

--- a/src/server/models/listItem/providers/deserialisers/TranslatorInterpreter.deserialiser.ts
+++ b/src/server/models/listItem/providers/deserialisers/TranslatorInterpreter.deserialiser.ts
@@ -20,6 +20,5 @@ export const translatorInterpreterDeserialiser: WebhookDeserialisers[ServiceType
     interpreterServices: checkboxCSVToArray(interpreterServices),
     languagesProvided: checkboxCSVToArray(languagesProvided),
     ...rest,
-    country: webhookData.addressCountry!,
   };
 };


### PR DESCRIPTION
The addressCountry information is used to populate the country for application forms. Without it the translators form won't work.