### PR TITLE
feat: Update annual-review declaration

### DIFF
--- a/src/scheduler/workers/processListsBeforeAndDuringStart/govukNotify.ts
+++ b/src/scheduler/workers/processListsBeforeAndDuringStart/govukNotify.ts
@@ -75,7 +75,7 @@ export async function sendAnnualReviewPostEmail(
       )}`
     );
     const result = await getNotifyClient().sendEmail(notifyTemplate, emailAddress, { personalisation, reference: "" });
-    return { result: (result as NotifyResult).statusText === "Created" };
+    return { result: (result as NotifyResult).statusText.toLowerCase() === "created" };
   } catch (error) {
     const message = `sendAnnualReviewPostEmail: Unable to send annual review post email: ${error.message}`;
     logger.error(message);

--- a/src/scheduler/workers/processListsBeforeAndDuringStart/main.ts
+++ b/src/scheduler/workers/processListsBeforeAndDuringStart/main.ts
@@ -29,16 +29,25 @@ async function processPostEmailsForList(
 ) {
   // Check if sent before
   let emailSent = false;
-  if (!list.users) {
+  const { users = [] } = list;
+  if (!users) {
     logger.info(
       `Unable to send email to post for ${milestoneTillAnnualReview}. No users identified for List ${list.id}.`
     );
     return;
   }
-  for (const user of list.users) {
+  const userEmails: string[] = users.map((user) => user.email);
+  if (userEmails.length === 0) {
+    logger.info(
+      `Unable to send email to post for ${milestoneTillAnnualReview}. No user email addresses found for List ${list.id}.`
+    );
+    return;
+  }
+
+  for (const user of userEmails) {
     const { result } = await sendAnnualReviewPostEmail(
       milestoneTillAnnualReview,
-      user.email,
+      user,
       lowerCase(startCase(list.type)),
       list?.country?.name ?? "",
       formatDate(list.nextAnnualReviewStartDate)

--- a/src/server/models/listItem/providers/TranslatorsInterpreters.ts
+++ b/src/server/models/listItem/providers/TranslatorsInterpreters.ts
@@ -28,7 +28,7 @@ export async function findPublishedTranslatorsInterpretersPerCountry(
   const {
     region,
     servicesProvided = ["translation", "interpretation"],
-    languagesProvided,
+    languagesProvided = [],
     interpreterServices = [],
     translationSpecialties = [],
     offset = 0,
@@ -37,14 +37,14 @@ export async function findPublishedTranslatorsInterpretersPerCountry(
   const countryName = startCase(toLower(props.countryName));
   const andWhere: string[] = [];
 
-  if (languagesProvided) {
+  if (languagesProvided && languagesProvided.length > 0) {
     andWhere.push(
       `AND ARRAY(select lower(jsonb_array_elements_text("ListItem"."jsonData"->'languagesProvided'))) && ARRAY ${JSON.stringify(
         languagesProvided
       ).replace(/"/g, "'")}`
     );
   }
-  if (servicesProvided) {
+  if (servicesProvided && servicesProvided.length > 0) {
     andWhere.push(
       `AND ARRAY(select lower(jsonb_array_elements_text("ListItem"."jsonData"->'servicesProvided'))) && ARRAY ${JSON.stringify(
         servicesProvided

--- a/src/server/views/annual-review/declaration.njk
+++ b/src/server/views/annual-review/declaration.njk
@@ -25,18 +25,26 @@
 
     <p class="govuk-body">By continuing you declare that you are:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>
-        currently qualified to practise law or meet the national criteria for providing legal services to the public,
-        for example mandatory affiliation
-      </li>
-      <li>not disbarred from practising law</li>
-      <li>reliable and willing to help on a regular basis</li>
-      <li>able to respond within a reasonable timeframe to client requests</li>
-      <li>willing to update or re-confirm your details on a bi-annual basis on request</li>
-      <li>
-        aware that inclusion on the 'Find a lawyer abroad' service is not an endorsement by the FCDO and you are not
-        affiliated to the FCDO in any way
-      </li>
+      {% if listType == 'lawyers' %}
+        <li>currently qualified to practise law or meet the national criteria for providing legal services to the public, for example mandatory affiliation</li>
+        <li>not disbarred from practising law</li>
+        <li>reliable and willing to help on a regular basis</li>
+        <li>able to respond within a reasonable timeframe to client requests</li>
+        <li>willing to update or re-confirm your details on a bi-annual basis on request</li>
+        <li>aware that inclusion on the 'Find a lawyer abroad' service is not an endorsement by the FCDO and you are not affiliated to the FCDO in any way</li>
+      {% elif listType == 'funeralDirectors' %}
+         <li>currently qualified to provide funeral services, or are currently registered with the local authorities to provide funeral services (if applicable in your country)</li>
+         <li>reliable and willing to help on a regular basis</li>
+         <li>able to respond within a reasonable timeframe to client requests</li>
+         <li>willing to update or re-confirm your details on an annual basis on request</li>
+         <li>aware that inclusion on the 'Find an English-speaking funeral director abroad' service is not an endorsement by the FCDO and you are not affiliated to the FCDO in any way</li>
+      {% elif listType == 'translatorsInterpreters' %}
+         <li>currently qualified to provide translation or interpretation services</li>
+         <li>reliable and willing to help on a regular basis</li>
+         <li>able to respond within a reasonable timeframe to client requests</li>
+         <li>willing to update or re-confirm your details on an annual basis on request</li>
+         <li>aware that inclusion on the 'Find an English-speaking translator or interpreter abroad' service is not an endorsement by the FCDO and you are not affiliated to the FCDO in any way</li>
+      {% endif %}
     </ul>
 
     <p class="govuk-body">

--- a/src/server/views/lists/partials/lawyers/macros.njk
+++ b/src/server/views/lists/partials/lawyers/macros.njk
@@ -62,7 +62,7 @@
   </h3>
   {% if item.jsonData.contactName %}
     <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">
-      <strong>{{ _.startCase(_.toLower(item.jsonData.contactName)) }}</strong>
+      <strong>{{ item.jsonData.contactName }}</strong>
     </p>
   {% endif %}
   <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">

--- a/src/shared/getNotifyClient.ts
+++ b/src/shared/getNotifyClient.ts
@@ -21,7 +21,7 @@ export function getNotifyClient() {
 
 class FakeNotifyClient {
   sendEmail() {
-    return { statusText: "Created" };
+    return { statusText: "created" };
   }
 }
 


### PR DESCRIPTION
**Summary**
This pull request includes the following updates and fixes:

1. User Declaration for Annual Review
Updated the user declaration process to have a declaration per list, not just for lawyers. Previously, the lawyer declaration was displayed for all users.

2. Fix Annual Review Emails
Corrected the issue where annual review emails were being sent to posts without properly checking the response. This caused the emails to appear as failures, preventing their insertion into the audit table and resulting in repeated attempts the next day.

3. Remove Formatting on Lawyer Contact Details
Removed formatting from lawyer contact details, ensuring that the lawyer's name is displayed as entered. This allows for adjustments to be made via the admin dashboard.